### PR TITLE
decoders: h264: fix spurious drain when processing a sps

### DIFF
--- a/src/decoders/h264/decoder.rs
+++ b/src/decoders/h264/decoder.rs
@@ -2147,9 +2147,7 @@ where
         while let Ok(Some(nalu)) = Nalu::next(&mut cursor) {
             match nalu.header().nalu_type() {
                 NaluType::Sps => {
-                    // Clone to avoid double-borrow on `self`.
-                    let sps = self.parser.parse_sps(&nalu)?.clone();
-                    self.apply_sps(&sps);
+                    self.parser.parse_sps(&nalu)?;
                 }
 
                 NaluType::Pps => {


### PR DESCRIPTION
The negotiation code in cros-codecs was refactored such that:

- A client *must* acknowledge a new format before decoding can resume
- When the new format is acknowledged, the data that originated the format change is applied. For h.264, this means calling apply_sps().

In particular, the apply_sps() function assumes that a *new* sps was found. This means that the dpb is drained and the pictures outputted as needed, as it is assumed that all references are now invalid given the format change.

The current code calls apply_sps twice. Once during the negotiation path, when the SPS is peeked, and once during the actual SPS processing. It does so unconditionally in the latter case. This means that any stream containing multiple (identical) SPS are automatically broken as re-applying the same SPS will clear the DPB while its references frames are still valid.

Having identical SPS nalus throughout the stream is common, as this protects against packet loss from network transmission.

Remove the extra apply_sps() call, leaving the one protected by negotiation_needed() during the format negotiation process.

This commit fixes the following test vectors, as tested by Fluster:

CAWP5_TOSHIBA_E
CVWP2_TOSHIBA_E
CVWP3_TOSHIBA_E
CVWP5_TOSHIBA_E

The score improves from 118 to 122 for the JVT-AVC_V1 test suite.