### PR TITLE
ccdec: do not assume h264 as the default coded format

### DIFF
--- a/examples/ccdec.rs
+++ b/examples/ccdec.rs
@@ -107,8 +107,8 @@ struct Args {
     #[argh(option)]
     output: Option<PathBuf>,
 
-    /// input format to decode from. Default: h264
-    #[argh(option, default = "EncodedFormat::H264")]
+    /// input format to decode from.
+    #[argh(option)]
     input_format: EncodedFormat,
 
     /// pixel format to decode into. Default: i420


### PR DESCRIPTION
H.264 is very popular, but it is still not a good idea to simply assume it as a default.

Passing some random data as an h.264 stream crashes cros-codecs, or produces no useful output as no valid NALUs are parsed. This is the best-case scenario, but we should not rely on that.

Leave the responsibility of properly labelling the data to the user.