### PR TITLE
h264: fix off-by-one in the RPLM algorithm

### DIFF
--- a/src/decoders/h264/decoder.rs
+++ b/src/decoders/h264/decoder.rs
@@ -1883,7 +1883,7 @@ where
 
         let mut nidx = *ref_idx_lx;
 
-        for cidx in *ref_idx_lx..=usize::from(num_ref_idx_lx_active_minus1) {
+        for cidx in *ref_idx_lx..=usize::from(num_ref_idx_lx_active_minus1) + 1 {
             if cidx == ref_pic_list_x.len() {
                 break;
             }
@@ -1938,7 +1938,7 @@ where
             RefPicList::RefPicList1 => current_slice.header().num_ref_idx_l1_active_minus1(),
         };
 
-        for cidx in *ref_idx_lx..=usize::from(num_ref_idx_lx_active_minus1) {
+        for cidx in *ref_idx_lx..=usize::from(num_ref_idx_lx_active_minus1) + 1 {
             if cidx == ref_pic_list_x.len() {
                 break;
             }


### PR DESCRIPTION
The reference picture list modification algorithm had a off by one error in both the short term and long term code paths.

This would left shift the lists incorrectly, which would corrupt their state.

The algorithms are from equations 8-37 and 8-38 in the specification.

Fixes the following JVT_AVC_V1 tests:

MR1_BT_A
MR2_TANDBERG_E
MR6_BT_B
MR7_BT_B

Current score is 124/135 on Intel platforms.