### PR TITLE
VP9: Implement support for inter-frame DRC 

### DIFF
--- a/src/decoders.rs
+++ b/src/decoders.rs
@@ -283,6 +283,9 @@ pub trait DecodedHandle {
     /// Returns the timestamp of the picture.
     fn timestamp(&self) -> u64;
 
+    /// Returns the coded resolution at the time this handle was decoded.
+    fn coded_resolution(&self) -> Resolution;
+
     /// Returns the display resolution at the time this handle was decoded.
     fn display_resolution(&self) -> Resolution;
 

--- a/src/decoders/h264/backends/vaapi.rs
+++ b/src/decoders/h264/backends/vaapi.rs
@@ -549,6 +549,7 @@ impl StatelessDecoderBackend for VaapiBackend<Sps> {
         let metadata = self.metadata_state.get_parsed_mut()?;
         let surface = metadata
             .surface_pool
+            .borrow_mut()
             .get_surface()
             .ok_or(StatelessBackendError::OutOfResources)?;
 

--- a/src/decoders/vp8/backends/vaapi.rs
+++ b/src/decoders/vp8/backends/vaapi.rs
@@ -242,7 +242,7 @@ impl StatelessDecoderBackend for VaapiBackend<Header> {
 
         let metadata = self.metadata_state.get_parsed_mut()?;
         let context = &metadata.context;
-        let coded_resolution = metadata.surface_pool.coded_resolution();
+        let coded_resolution = metadata.surface_pool.borrow().coded_resolution();
 
         let iq_buffer = context
             .create_buffer(Self::build_iq_matrix(picture, segmentation)?)
@@ -274,6 +274,7 @@ impl StatelessDecoderBackend for VaapiBackend<Header> {
 
         let surface = metadata
             .surface_pool
+            .borrow_mut()
             .get_surface()
             .ok_or(StatelessBackendError::OutOfResources)?;
 

--- a/src/decoders/vp9/backends/vaapi.rs
+++ b/src/decoders/vp9/backends/vaapi.rs
@@ -274,6 +274,7 @@ impl StatelessDecoderBackend for VaapiBackend<Header> {
 
         let surface = metadata
             .surface_pool
+            .borrow_mut()
             .get_surface()
             .ok_or(StatelessBackendError::OutOfResources)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,15 @@ pub struct Resolution {
     pub height: u32,
 }
 
+impl From<(u32, u32)> for Resolution {
+    fn from(value: (u32, u32)) -> Self {
+        Self {
+            width: value.0,
+            height: value.1,
+        }
+    }
+}
+
 /// Formats that buffers can be mapped into for the CPU to read.
 ///
 /// The conventions here largely follow these of libyuv.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,13 @@ pub struct Resolution {
     pub height: u32,
 }
 
+impl Resolution {
+    /// Whether `self` can contain `other`.
+    pub fn can_contain(&self, other: Self) -> bool {
+        self.width >= other.width && self.height >= other.height
+    }
+}
+
 impl From<(u32, u32)> for Resolution {
     fn from(value: (u32, u32)) -> Self {
         Self {

--- a/src/utils/dummy.rs
+++ b/src/utils/dummy.rs
@@ -48,6 +48,10 @@ impl Clone for Handle {
 }
 
 impl DecodedHandle for Handle {
+    fn coded_resolution(&self) -> Resolution {
+        Default::default()
+    }
+
     fn display_resolution(&self) -> Resolution {
         Default::default()
     }


### PR DESCRIPTION
Improves the Fluster score from 272/305 to 295/305 on Intel.