### PR TITLE
Fix MR3_TANDBERG_B on Intel

### DIFF
--- a/src/decoders/h264/backends/vaapi.rs
+++ b/src/decoders/h264/backends/vaapi.rs
@@ -266,7 +266,7 @@ impl VaapiBackend<Sps> {
             sps.frame_mbs_only_flag() as u32,
             sps.mb_adaptive_frame_field_flag() as u32,
             sps.direct_8x8_inference_flag() as u32,
-            (sps.level_idc() > Level::L3_1) as u32, /* see A.3.3.2 */
+            (sps.level_idc() >= Level::L3_1) as u32, /* see A.3.3.2 */
             sps.log2_max_frame_num_minus4() as u32,
             sps.pic_order_cnt_type() as u32,
             sps.log2_max_pic_order_cnt_lsb_minus4() as u32,

--- a/src/decoders/h264/decoder.rs
+++ b/src/decoders/h264/decoder.rs
@@ -1518,13 +1518,16 @@ where
             .context("Invalid SPS while handling a frame_num gap")?;
 
         if !sps.gaps_in_frame_num_value_allowed_flag() {
-            return Err(anyhow!("Invalid frame_num: {}", frame_num));
+            return Err(anyhow!(
+                "Invalid frame_num: {}. Assuming unintentional loss of pictures",
+                frame_num
+            ));
         }
 
         let mut unused_short_term_frame_num =
             (self.prev_ref_pic_info.frame_num + 1) % self.curr_info.max_frame_num;
         while unused_short_term_frame_num != frame_num {
-            let mut pic = PictureData::new_non_existing(frame_num, timestamp);
+            let mut pic = PictureData::new_non_existing(unused_short_term_frame_num, timestamp);
             self.compute_pic_order_count(&mut pic)?;
 
             self.update_pic_nums(unused_short_term_frame_num, &pic)?;

--- a/src/decoders/h264/decoder.rs
+++ b/src/decoders/h264/decoder.rs
@@ -1403,7 +1403,7 @@ where
     }
 
     /// Adds picture to the ready queue if it could not be added to the DPB.
-    fn add_to_ready_queue(&mut self, pic_rc: Rc<RefCell<PictureData>>, handle: T) {
+    fn add_to_ready_queue_directly(&mut self, pic_rc: Rc<RefCell<PictureData>>, handle: T) {
         let pic = pic_rc.borrow();
 
         if matches!(pic.field, Field::Frame) {
@@ -1503,7 +1503,7 @@ where
             }
         } else {
             drop(pic);
-            self.add_to_ready_queue(pic_rc, handle);
+            self.add_to_ready_queue_directly(pic_rc, handle);
         }
 
         Ok(())


### PR DESCRIPTION
Fixes MR3_TANDBERG_B on Intel. Test remains broken on AMD both on GStreamer and cros-codecs.

Compared with JM, saw no difference in terms of the data sent at the affected frames (#283-#299)

ffmpeg reverts to software decoding.

My guess is that the AMD driver probably dislikes the long term reference introduced on frame #283 somehow.

[ccdec.zip (on AMD)](https://github.com/chromeos/cros-codecs/files/11670955/ccdec.zip)

Partially addresses #9 
