### PR TITLE
decoders: vaapi: add support for odd resolutions

### DIFF
--- a/src/backend/vaapi.rs
+++ b/src/backend/vaapi.rs
@@ -357,7 +357,10 @@ impl StreamMetadataState {
     ) -> anyhow::Result<StreamMetadataState> {
         let va_profile = hdr.va_profile()?;
         let rt_format = hdr.rt_format()?;
-        let (frame_w, frame_h) = hdr.coded_size();
+
+        let (frame_w, frame_h) = Resolution::from(hdr.coded_size())
+            .round(crate::ResolutionRoundMode::Even)
+            .into();
 
         let format_map = if let Some(format_map) = format_map {
             format_map
@@ -570,8 +573,8 @@ impl GenericBackendHandle {
                 // Map the VASurface onto our address space.
                 let image = picture.create_image(
                     *self.map_format,
-                    self.display_resolution.width,
-                    self.display_resolution.height,
+                    self.coded_resolution.into(),
+                    self.display_resolution.into(),
                 )?;
 
                 Ok(image)
@@ -638,8 +641,9 @@ impl<'a> MappableHandle for Image<'a> {
         let image_size = self.image_size();
         let image_inner = self.image();
 
-        let width = image_inner.width as usize;
-        let height = image_inner.height as usize;
+        let display_resolution = self.display_resolution();
+        let width = display_resolution.0 as usize;
+        let height = display_resolution.1 as usize;
 
         if buffer.len() != image_size {
             return Err(anyhow!(
@@ -715,11 +719,11 @@ impl<'a> MappableHandle for Image<'a> {
 
     fn image_size(&mut self) -> usize {
         let image = self.image();
-
+        let display_resolution = self.display_resolution();
         crate::decoded_frame_size(
             (&image.format).try_into().unwrap(),
-            image.width as usize,
-            image.height as usize,
+            display_resolution.0 as usize,
+            display_resolution.1 as usize,
         )
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,13 @@ use byteorder::LittleEndian;
 #[cfg(feature = "vaapi")]
 pub use libva;
 
+/// Rounding modes for `Resolution`
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ResolutionRoundMode {
+    /// Rounds component-wise to the next even value.
+    Even,
+}
+
 /// A frame resolution in pixels.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct Resolution {
@@ -41,6 +48,23 @@ impl Resolution {
     pub fn can_contain(&self, other: Self) -> bool {
         self.width >= other.width && self.height >= other.height
     }
+
+    /// Rounds `self` according to `rnd_mode`.
+    pub fn round(mut self, rnd_mode: ResolutionRoundMode) -> Self {
+        match rnd_mode {
+            ResolutionRoundMode::Even => {
+                if self.width % 2 != 0 {
+                    self.width += 1;
+                }
+
+                if self.height % 2 != 0 {
+                    self.height += 1;
+                }
+            }
+        }
+
+        self
+    }
 }
 
 impl From<(u32, u32)> for Resolution {
@@ -49,6 +73,12 @@ impl From<(u32, u32)> for Resolution {
             width: value.0,
             height: value.1,
         }
+    }
+}
+
+impl From<Resolution> for (u32, u32) {
+    fn from(value: Resolution) -> Self {
+        (value.width, value.height)
     }
 }
 


### PR DESCRIPTION
Add support for odd resolutions. This basically uses the rounded coded resolution for surface creation and the display resolution for copying the YUV data.

This increases the scores on Intel as follows:

VP8 - 60/61
VP9 - 302/305

The score for H.264 remains unchanged at 126/135.

Needs https://github.com/chromeos/cros-libva/pull/1 to land first