### PR TITLE
Improve JVT-FR-EXT test scores

### DIFF
--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -560,6 +560,7 @@ pub enum Profile {
     Main = 77,
     Extended = 88,
     High = 100,
+    High10 = 110,
     High422P = 122,
 }
 

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -50,7 +50,7 @@ fn get_raster_from_zigzag_8x8(src: [u8; 64], dst: &mut [u8; 64]) {
     ];
 
     for i in 0..64 {
-        dst[i] = src[ZIGZAG_8X8[i]];
+        dst[ZIGZAG_8X8[i]] = src[i];
     }
 }
 
@@ -58,7 +58,7 @@ fn get_raster_from_zigzag_4x4(src: [u8; 16], dst: &mut [u8; 16]) {
     const ZIGZAG_4X4: [usize; 16] = [0, 1, 4, 8, 5, 2, 3, 6, 9, 12, 13, 10, 7, 11, 14, 15];
 
     for i in 0..16 {
-        dst[i] = src[ZIGZAG_4X4[i]];
+        dst[ZIGZAG_4X4[i]] = src[i];
     }
 }
 

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -62,8 +62,9 @@ impl StreamInfo for &Sps {
                     ))
                 }
             }
-            Profile::High => Ok(libva::VAProfile::VAProfileH264High),
-            Profile::High422P => Ok(libva::VAProfile::VAProfileH264High),
+            Profile::High | Profile::High422P | Profile::High10 => {
+                Ok(libva::VAProfile::VAProfileH264High)
+            }
         }
     }
 


### PR DESCRIPTION
This PR improves the score to 42/61 on Intel.

Other issues include:

a) the apparent lack of support for HIGH10 on the Intel driver.
b) https://github.com/intel/media-driver/issues/1683, but for H.264, which makes vaEndPicture return VA_INVALID_PARAMETER on the Intel driver.

None of these things can be worked from cros-codecs itself.