### PR TITLE
Pooled surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 [[package]]
 name = "cros-libva"
 version = "0.0.3"
-source = "git+https://github.com/chromeos/cros-libva?rev=15dcc6de#15dcc6de29b668f0960169045910f36dd0712b71"
+source = "git+https://github.com/chromeos/cros-libva?rev=50d47af#50d47afc5d3346dd39bb3cd2306aa833725042f2"
 dependencies = [
  "bitflags",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ byteorder = "1.4.3"
 bytes = "1.1.0"
 enumn = "0.1.4"
 #libva = { version = "0.0.3", package = "cros-libva", optional = true }
-libva = { git = "https://github.com/chromeos/cros-libva", rev = "15dcc6de", package = "cros-libva", optional = true }
+libva = { git = "https://github.com/chromeos/cros-libva", rev = "50d47af", package = "cros-libva", optional = true }
 log = { version = "0", features = ["release_max_level_debug"] }
 thiserror = "1.0.31"
 crc32fast = "1.3.2"

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -15,6 +15,7 @@ use libva::PictureNew;
 use libva::PictureParameter;
 use libva::PictureParameterBufferH264;
 use libva::SliceParameter;
+use libva::Surface;
 
 use crate::backend::vaapi::DecodedHandle as VADecodedHandle;
 use crate::backend::vaapi::StreamInfo;
@@ -462,7 +463,7 @@ impl VaapiBackend<Sps> {
 }
 
 impl StatelessH264DecoderBackend for VaapiBackend<Sps> {
-    type Picture = VaPicture<PictureNew, ()>;
+    type Picture = VaPicture<PictureNew, Surface<()>>;
 
     fn new_sequence(&mut self, sps: &Sps) -> StatelessBackendResult<()> {
         self.new_sequence(sps)
@@ -480,7 +481,7 @@ impl StatelessH264DecoderBackend for VaapiBackend<Sps> {
         let metadata = self.metadata_state.get_parsed()?;
         let context = &metadata.context;
 
-        let surface_id = picture.surface_id();
+        let surface_id = picture.surface().id();
 
         let pic_param = Self::build_pic_param(slice, picture_data, surface_id, dpb, sps, pps)?;
         let pic_param = context
@@ -574,7 +575,7 @@ impl StatelessH264DecoderBackend for VaapiBackend<Sps> {
     }
 }
 
-impl Decoder<VADecodedHandle, VaPicture<PictureNew, ()>> {
+impl Decoder<VADecodedHandle, VaPicture<PictureNew, Surface<()>>> {
     // Creates a new instance of the decoder using the VAAPI backend.
     pub fn new_vaapi(display: Rc<Display>, blocking_mode: BlockingMode) -> anyhow::Result<Self> {
         Self::new(Box::new(VaapiBackend::<Sps>::new(display)), blocking_mode)

--- a/src/decoder/stateless/vp8/vaapi.rs
+++ b/src/decoder/stateless/vp8/vaapi.rs
@@ -275,7 +275,7 @@ impl StatelessVp8DecoderBackend for VaapiBackend<Header> {
         let surface = metadata
             .surface_pool
             .borrow_mut()
-            .get_surface()
+            .get_surface(&metadata.surface_pool)
             .ok_or(StatelessBackendError::OutOfResources)?;
 
         let mut va_picture = VaPicture::new(timestamp, Rc::clone(context), surface);

--- a/src/decoder/stateless/vp9/vaapi.rs
+++ b/src/decoder/stateless/vp9/vaapi.rs
@@ -275,7 +275,7 @@ impl StatelessVp9DecoderBackend for VaapiBackend<Header> {
         let surface = metadata
             .surface_pool
             .borrow_mut()
-            .get_surface()
+            .get_surface(&metadata.surface_pool)
             .ok_or(StatelessBackendError::OutOfResources)?;
 
         let mut va_picture = VaPicture::new(timestamp, Rc::clone(context), surface);


### PR DESCRIPTION
This PR takes advantage of the latest libva code (which allows any type owning a Surface to be the target of a Picture) to streamline a bit the pool code and avoid some of the gymnastics we were doing to simply return surfaces into the pool.

Doing so allows us to safely keep better accounting of the surfaces managed by the pool, and to optimize surface allocation. It will also be necessary for future changes where we move surface allocation to the client, which in turn will allow the client to provide the memory for backing these surfaces.

Asking for a code review since we got things wrong in the past with buffer pool management, so an extra pair of eyes would be welcome! :)