### PR TITLE
More H.265 changes

### DIFF
--- a/examples/ccdec.rs
+++ b/examples/ccdec.rs
@@ -18,6 +18,8 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use argh::FromArgs;
+use cros_codecs::codec::h264::parser::Nalu as H264Nalu;
+use cros_codecs::codec::h265::parser::Nalu as H265Nalu;
 use cros_codecs::decoder::stateless::h264::H264;
 use cros_codecs::decoder::stateless::h265::H265;
 use cros_codecs::decoder::stateless::vp8::Vp8;
@@ -32,9 +34,8 @@ use cros_codecs::utils::simple_playback_loop;
 use cros_codecs::utils::simple_playback_loop_owned_surfaces;
 use cros_codecs::utils::simple_playback_loop_userptr_surfaces;
 use cros_codecs::utils::DmabufSurface;
-use cros_codecs::utils::H264FrameIterator;
-use cros_codecs::utils::H265FrameIterator;
 use cros_codecs::utils::IvfIterator;
+use cros_codecs::utils::NalIterator;
 use cros_codecs::utils::UserPtrSurface;
 use cros_codecs::DecodedFormat;
 use cros_codecs::Fourcc;
@@ -337,7 +338,7 @@ fn main() {
     let display = libva::Display::open().expect("failed to open libva display");
     let (mut decoder, frame_iter) = match args.input_format {
         EncodedFormat::H264 => {
-            let frame_iter = Box::new(H264FrameIterator::new(&input).map(Cow::Borrowed))
+            let frame_iter = Box::new(NalIterator::<H264Nalu<_>>::new(&input).map(Cow::Borrowed))
                 as Box<dyn Iterator<Item = Cow<[u8]>>>;
 
             let decoder = Box::new(StatelessDecoder::<H264, _>::new_vaapi(
@@ -368,7 +369,7 @@ fn main() {
             (decoder, frame_iter)
         }
         EncodedFormat::H265 => {
-            let frame_iter = Box::new(H265FrameIterator::new(&input).map(Cow::Borrowed))
+            let frame_iter = Box::new(NalIterator::<H265Nalu<_>>::new(&input).map(Cow::Borrowed))
                 as Box<dyn Iterator<Item = Cow<[u8]>>>;
 
             let decoder = Box::new(StatelessDecoder::<H265, _>::new_vaapi(

--- a/examples/ccdec.rs
+++ b/examples/ccdec.rs
@@ -19,6 +19,7 @@ use std::str::FromStr;
 
 use argh::FromArgs;
 use cros_codecs::decoder::stateless::h264::H264;
+use cros_codecs::decoder::stateless::h265::H265;
 use cros_codecs::decoder::stateless::vp8::Vp8;
 use cros_codecs::decoder::stateless::vp9::Vp9;
 use cros_codecs::decoder::stateless::StatelessDecoder;
@@ -370,10 +371,10 @@ fn main() {
             let frame_iter = Box::new(H265FrameIterator::new(&input).map(Cow::Borrowed))
                 as Box<dyn Iterator<Item = Cow<[u8]>>>;
 
-            let decoder = Box::new(
-                cros_codecs::decoder::stateless::h265::Decoder::new_vaapi(display, blocking_mode)
-                    .expect("failed to create decoder"),
-            ) as Box<dyn StatelessVideoDecoder<_>>;
+            let decoder = Box::new(StatelessDecoder::<H265, _>::new_vaapi(
+                display,
+                blocking_mode,
+            )) as Box<dyn StatelessVideoDecoder<_>>;
 
             (decoder, frame_iter)
         }

--- a/src/codec/h264/nalu.rs
+++ b/src/codec/h264/nalu.rs
@@ -74,7 +74,12 @@ where
             next_nalu_offset -= 1;
         }
 
-        let nal_size = if hdr.is_end() { 1 } else { next_nalu_offset };
+        let nal_size = if hdr.is_end() {
+            // the NALU is comprised of only the header
+            hdr.len()
+        } else {
+            next_nalu_offset
+        };
 
         Ok(Nalu {
             header: hdr,

--- a/src/codec/vp9/parser.rs
+++ b/src/codec/vp9/parser.rs
@@ -320,9 +320,9 @@ pub struct Frame<T: AsRef<[u8]>> {
     /// The frame header.
     pub header: Header,
     /// The offset into T
-    pub offset: usize,
+    offset: usize,
     /// The size of the data in T
-    pub size: usize,
+    size: usize,
 }
 
 impl<T: AsRef<[u8]>> Frame<T> {

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -1955,6 +1955,7 @@ where
 
 #[cfg(test)]
 pub mod tests {
+    use crate::codec::h264::parser::Nalu;
     use crate::decoder::stateless::h264::H264;
     use crate::decoder::stateless::tests::test_decode_stream;
     use crate::decoder::stateless::tests::TestStream;
@@ -1962,7 +1963,7 @@ pub mod tests {
     use crate::decoder::BlockingMode;
     use crate::utils::simple_playback_loop;
     use crate::utils::simple_playback_loop_owned_surfaces;
-    use crate::utils::H264FrameIterator;
+    use crate::utils::NalIterator;
     use crate::DecodedFormat;
 
     /// Run `test` using the dummy decoder, in both blocking and non-blocking modes.
@@ -1973,7 +1974,7 @@ pub mod tests {
             |d, s, f| {
                 simple_playback_loop(
                     d,
-                    H264FrameIterator::new(s),
+                    NalIterator::<Nalu<_>>::new(s),
                     f,
                     &mut simple_playback_loop_owned_surfaces,
                     DecodedFormat::NV12,

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -588,6 +588,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessDecoder<H264, VaapiBackend<(
 mod tests {
     use libva::Display;
 
+    use crate::codec::h264::parser::Nalu;
     use crate::decoder::stateless::h264::H264;
     use crate::decoder::stateless::tests::test_decode_stream;
     use crate::decoder::stateless::tests::TestStream;
@@ -595,7 +596,7 @@ mod tests {
     use crate::decoder::BlockingMode;
     use crate::utils::simple_playback_loop;
     use crate::utils::simple_playback_loop_owned_surfaces;
-    use crate::utils::H264FrameIterator;
+    use crate::utils::NalIterator;
     use crate::DecodedFormat;
 
     /// Run `test` using the vaapi decoder, in both blocking and non-blocking modes.
@@ -611,7 +612,7 @@ mod tests {
             |d, s, f| {
                 simple_playback_loop(
                     d,
-                    H264FrameIterator::new(s),
+                    NalIterator::<Nalu<_>>::new(s),
                     f,
                     &mut simple_playback_loop_owned_surfaces,
                     output_format,

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -580,7 +580,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessDecoder<H264, VaapiBackend<(
         M: From<S>,
         S: From<M>,
     {
-        Self::new(VaapiBackend::<(), M>::new(display), blocking_mode)
+        Self::new(VaapiBackend::<(), M>::new(display, false), blocking_mode)
     }
 }
 

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -1309,6 +1309,7 @@ where
 #[cfg(test)]
 pub mod tests {
 
+    use crate::codec::h265::parser::Nalu;
     use crate::decoder::stateless::h265::H265;
     use crate::decoder::stateless::tests::test_decode_stream;
     use crate::decoder::stateless::tests::TestStream;
@@ -1316,7 +1317,7 @@ pub mod tests {
     use crate::decoder::BlockingMode;
     use crate::utils::simple_playback_loop;
     use crate::utils::simple_playback_loop_owned_surfaces;
-    use crate::utils::H265FrameIterator;
+    use crate::utils::NalIterator;
     use crate::DecodedFormat;
 
     /// Run `test` using the dummy decoder, in both blocking and non-blocking modes.
@@ -1327,7 +1328,7 @@ pub mod tests {
             |d, s, f| {
                 simple_playback_loop(
                     d,
-                    H265FrameIterator::new(s),
+                    NalIterator::<Nalu<_>>::new(s),
                     f,
                     &mut simple_playback_loop_owned_surfaces,
                     DecodedFormat::NV12,

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -26,17 +26,17 @@ use crate::codec::h265::parser::SliceHeader;
 use crate::codec::h265::parser::Sps;
 use crate::codec::h265::picture::PictureData;
 use crate::codec::h265::picture::Reference;
-use crate::decoder::stateless::private;
 use crate::decoder::stateless::DecodeError;
 use crate::decoder::stateless::DecodingState;
 use crate::decoder::stateless::StatelessBackendResult;
+use crate::decoder::stateless::StatelessCodec;
+use crate::decoder::stateless::StatelessDecoder;
 use crate::decoder::stateless::StatelessDecoderBackend;
 use crate::decoder::stateless::StatelessDecoderFormatNegotiator;
 use crate::decoder::stateless::StatelessVideoDecoder;
 use crate::decoder::BlockingMode;
 use crate::decoder::DecodedHandle;
 use crate::decoder::DecoderEvent;
-use crate::decoder::ReadyFramesQueue;
 use crate::decoder::StreamInfo;
 use crate::decoder::SurfacePool;
 use crate::Resolution;
@@ -54,8 +54,54 @@ pub(crate) fn clip3(x: i32, y: i32, z: i32) -> i32 {
     }
 }
 
+// See 6.5.3
+const fn up_right_diagonal<const N: usize, const ROWS: usize>() -> [usize; N] {
+    // Generics can't be used in const operations for now, so [0; ROWS * ROWS]
+    // is rejected by the compiler
+    assert!(ROWS * ROWS == N);
+
+    let mut i = 0;
+    let mut x = 0i32;
+    let mut y = 0i32;
+    let mut ret = [0; N];
+
+    loop {
+        while y >= 0 {
+            if x < (ROWS as i32) && y < (ROWS as i32) {
+                ret[i] = (x + ROWS as i32 * y) as usize;
+                i += 1;
+            }
+            y -= 1;
+            x += 1;
+        }
+
+        y = x;
+        x = 0;
+        if i >= N {
+            break;
+        }
+    }
+
+    ret
+}
+
+const UP_RIGHT_DIAGONAL_4X4: [usize; 16] = up_right_diagonal::<16, 4>();
+const UP_RIGHT_DIAGONAL_8X8: [usize; 64] = up_right_diagonal::<64, 8>();
+
+fn get_raster_from_up_right_diagonal_8x8(src: [u8; 64], dst: &mut [u8; 64]) {
+    for i in 0..64 {
+        dst[UP_RIGHT_DIAGONAL_8X8[i]] = src[i];
+    }
+}
+
+fn get_raster_from_up_right_diagonal_4x4(src: [u8; 16], dst: &mut [u8; 16]) {
+    for i in 0..16 {
+        dst[UP_RIGHT_DIAGONAL_4X4[i]] = src[i];
+    }
+}
+
 /// Stateless backend methods specific to H.265.
-trait StatelessH265DecoderBackend: StatelessDecoderBackend<Sps> {
+pub trait StatelessH265DecoderBackend: StatelessDecoderBackend<Sps> {
     /// Called when a new SPS is parsed.
     fn new_sequence(&mut self, sps: &Sps) -> StatelessBackendResult<()>;
 
@@ -68,7 +114,7 @@ trait StatelessH265DecoderBackend: StatelessDecoderBackend<Sps> {
 
     /// Called by the decoder for every frame or field found.
     #[allow(clippy::too_many_arguments)]
-    fn handle_picture(
+    fn begin_picture(
         &mut self,
         picture: &mut Self::Picture,
         picture_data: &PictureData,
@@ -95,9 +141,6 @@ trait StatelessH265DecoderBackend: StatelessDecoderBackend<Sps> {
     /// Called when the decoder wants the backend to finish the decoding
     /// operations for `picture`. At this point, `decode_slice` has been called
     /// for all slices.
-    ///
-    /// This call will assign the ownership of the BackendHandle to the Picture
-    /// and then assign the ownership of the Picture to the Handle.
     fn submit_picture(&mut self, picture: Self::Picture) -> StatelessBackendResult<Self::Handle>;
 }
 
@@ -112,6 +155,11 @@ pub enum RefPicListEntry<T> {
 enum BumpingType {
     BeforeDecoding,
     AfterDecoding,
+}
+
+enum RenegotiationType<'a> {
+    CurrentSps,
+    NewSps(&'a Sps),
 }
 
 /// Keeps track of the last values seen for negotiation purposes.
@@ -142,7 +190,7 @@ impl From<&Sps> for NegotiationInfo {
 
 /// The RefPicSet data, derived once per picture.
 #[derive(Clone, Debug)]
-struct RefPicSet<T> {
+pub struct RefPicSet<T> {
     curr_delta_poc_msb_present_flag: [bool; MAX_DPB_SIZE],
     foll_delta_poc_msb_present_flag: [bool; MAX_DPB_SIZE],
 
@@ -189,54 +237,20 @@ impl<T: Clone> Default for RefPicSet<T> {
     }
 }
 
-pub struct Decoder<T, P>
-where
-    T: Clone,
-{
-    /// A parser to extract bitstream metadata
-    parser: Parser,
+/// State of the picture being currently decoded.
+///
+/// Stored between calls to [`StatelessDecoder::handle_slice`] that belong to the same picture.
+struct CurrentPicState<B: StatelessDecoderBackend<Sps>> {
+    /// Data for the current picture as extracted from the stream.
+    pic: PictureData,
+    /// Backend-specific data for that picture.
+    backend_pic: B::Picture,
+    /// List of reference pictures, used once per slice.
+    ref_pic_lists: ReferencePicLists<B::Handle>,
+}
 
-    /// Whether the decoder should block on decode operations.
-    blocking_mode: BlockingMode,
-
-    /// The backend used for hardware acceleration.
-    backend: Box<dyn StatelessH265DecoderBackend<Handle = T, Picture = P>>,
-
-    /// The backend used for hardware acceleration.
-    // backend: Box<dyn StatelessDecoderBackend<Handle = T, Picture = P>>,
-    decoding_state: DecodingState<Sps>,
-
-    /// Keeps track of the last values seen for negotiation purposes.
-    negotiation_info: NegotiationInfo,
-
-    rps: RefPicSet<T>,
-
-    ready_queue: ReadyFramesQueue<T>,
-
-    /// The decoded picture buffer
-    dpb: Dpb<T>,
-
-    /// The current active SPS id.
-    cur_sps_id: u8,
-    /// The current active PPS id.
-    cur_pps_id: u8,
-
-    /// The current picture being worked on. It is set during `handle_picture()`
-    /// and passed to the accelerator during `submit_picture()`.
-    cur_pic: Option<PictureData>,
-    /// The current picture representation on the backend side.
-    cur_backend_pic: Option<P>,
-
-    // Used to identify first picture in decoding order or first picture that
-    // follows an EOS NALU.
-    is_first_picture_in_au: bool,
-
-    // Same as PrevTid0Pic in the specification.
-    prev_tid_0_pic: Option<PictureData>,
-
-    // Internal variables needed during the decoding process.
-    max_pic_order_cnt_lsb: i32,
-
+/// All the reference picture lists used to decode a stream.
+struct ReferencePicLists<T> {
     /// Reference picture list 0 for P and B slices. Retains the same meaning as
     /// in the specification. Points into the pictures stored in the DPB.
     /// Derived once per slice.
@@ -245,48 +259,107 @@ where
     /// the specification. Points into the pictures stored in the DPB. Derived
     /// once per slice.
     ref_pic_list1: [Option<RefPicListEntry<T>>; MAX_DPB_SIZE],
+}
+
+impl<T> Default for ReferencePicLists<T> {
+    fn default() -> Self {
+        Self {
+            ref_pic_list0: Default::default(),
+            ref_pic_list1: Default::default(),
+        }
+    }
+}
+
+pub struct H265DecoderState<B: StatelessDecoderBackend<Sps>> {
+    /// A parser to extract bitstream metadata
+    parser: Parser,
+
+    /// Keeps track of the last values seen for negotiation purposes.
+    negotiation_info: NegotiationInfo,
+    /// The set of reference pictures.
+    rps: RefPicSet<B::Handle>,
+
+    /// The decoded picture buffer
+    dpb: Dpb<B::Handle>,
+
+    /// The current active SPS id.
+    cur_sps_id: u8,
+    /// The current active PPS id.
+    cur_pps_id: u8,
+
+    /// Used to identify first picture in decoding order or first picture that
+    /// follows an EOS NALU.
+    first_picture_after_eos: bool,
+
+    /// Whether this is the first picture in the bitstream in decoding order.
+    first_picture_in_bitstream: bool,
+    // Same as PrevTid0Pic in the specification.
+    prev_tid_0_pic: Option<PictureData>,
+
+    /// A H.265 syntax element.
+    max_pic_order_cnt_lsb: i32,
+    /// The value of NoRaslOutputFlag for the last IRAP picture.
+    irap_no_rasl_output_flag: bool,
+
     /// We keep track of the last independent header so we can copy that into
     /// dependent slices.
     last_independent_slice_header: Option<SliceHeader>,
+
+    /// The picture currently being decoded. We need to preserve it between
+    /// calls to `decode` because multiple slices will be processed in different
+    /// calls to `decode`.
+    current_pic: Option<CurrentPicState<B>>,
 }
 
-impl<T, P> Decoder<T, P>
+impl<B> Default for H265DecoderState<B>
 where
-    T: DecodedHandle + Clone,
+    B: StatelessH265DecoderBackend,
+    B::Handle: Clone,
 {
-    /// Create a new decoder using the given `backend`.
-    #[cfg(any(feature = "vaapi", test))]
-    #[allow(dead_code)]
-    fn new(
-        backend: Box<dyn StatelessH265DecoderBackend<Handle = T, Picture = P>>,
-        blocking_mode: BlockingMode,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
-            backend,
-            blocking_mode,
-            is_first_picture_in_au: true,
+    fn default() -> Self {
+        H265DecoderState {
             parser: Default::default(),
-            decoding_state: Default::default(),
             negotiation_info: Default::default(),
             rps: Default::default(),
-            ready_queue: Default::default(),
+            dpb: Default::default(),
             cur_sps_id: Default::default(),
             cur_pps_id: Default::default(),
-            cur_pic: Default::default(),
+            first_picture_after_eos: true,
+            first_picture_in_bitstream: true,
             prev_tid_0_pic: Default::default(),
             max_pic_order_cnt_lsb: Default::default(),
-            ref_pic_list0: Default::default(),
-            ref_pic_list1: Default::default(),
-            cur_backend_pic: Default::default(),
-            dpb: Default::default(),
+            irap_no_rasl_output_flag: Default::default(),
             last_independent_slice_header: Default::default(),
-        })
+            current_pic: Default::default(),
+        }
     }
+}
 
+/// [`StatelessCodec`] structure to use in order to create a H.265 stateless decoder.
+///
+/// # Accepted input
+///
+/// A decoder using this codec processes exactly one NAL unit of input per call to
+/// [`StatelessDecoder::decode`], and returns the number of bytes until the end of this NAL unit.
+/// This makes it possible to call [`Decode`](StatelessDecoder::decode) repeatedly on some unsplit
+/// Annex B stream and shrinking it by the number of bytes processed after each call, until the
+/// stream ends up being empty.
+pub struct H265;
+
+impl StatelessCodec for H265 {
+    type FormatInfo = Sps;
+    type DecoderState<B: StatelessDecoderBackend<Sps>> = H265DecoderState<B>;
+}
+
+impl<B> StatelessDecoder<H265, B>
+where
+    B: StatelessH265DecoderBackend,
+    B::Handle: Clone,
+{
     /// Whether the stream parameters have changed, indicating that a negotiation window has opened.
     fn negotiation_possible(
         sps: &Sps,
-        dpb: &Dpb<T>,
+        dpb: &Dpb<B::Handle>,
         old_negotiation_info: &NegotiationInfo,
     ) -> bool {
         let negotiation_info = NegotiationInfo::from(sps);
@@ -296,26 +369,14 @@ where
         *old_negotiation_info != negotiation_info || prev_max_dpb_size != max_dpb_size
     }
 
-    fn peek_sps(parser: &mut Parser, bitstream: &[u8]) -> anyhow::Result<Option<Sps>> {
-        let mut cursor = Cursor::new(bitstream);
-
-        while let Ok(nalu) = Nalu::next(&mut cursor) {
-            if matches!(nalu.header().type_(), NaluType::SpsNut) {
-                let sps = parser.parse_sps(&nalu)?;
-                return Ok(Some(sps.clone()));
-            }
-        }
-
-        Ok(None)
-    }
-
     /// Apply the parameters of `sps` to the decoder.
-    fn apply_sps(&mut self, sps: &Sps) {
-        self.drain();
-        self.negotiation_info = NegotiationInfo::from(sps);
+    fn apply_sps(&mut self, sps: &Sps) -> anyhow::Result<()> {
+        self.drain()?;
+        self.codec.negotiation_info = NegotiationInfo::from(sps);
 
         let max_dpb_size = std::cmp::min(sps.max_dpb_size(), 16);
-        self.dpb.set_max_num_pics(max_dpb_size);
+        self.codec.dpb.set_max_num_pics(max_dpb_size);
+        Ok(())
     }
 
     // See 8.3.2, Note 2.
@@ -328,37 +389,31 @@ where
     }
 
     // See 8.3.2.
-    fn decode_rps(&mut self, slice: &Slice<&[u8]>) -> anyhow::Result<()> {
+    fn decode_rps(&mut self, slice: &Slice<&[u8]>, cur_pic: &PictureData) -> anyhow::Result<()> {
         let hdr = slice.header();
-        let cur_pic = self.cur_pic.as_ref().unwrap();
 
-        if cur_pic.nal_unit_type.is_irap() && cur_pic.no_rasl_output_flag {
-            self.dpb.mark_all_as_unused_for_ref();
+        if cur_pic.nalu_type.is_irap() && cur_pic.no_rasl_output_flag {
+            self.codec.dpb.mark_all_as_unused_for_ref();
         }
 
-        if slice.nalu().header().type_().is_idr() {
-            self.rps.poc_st_curr_before = Default::default();
-            self.rps.poc_st_curr_after = Default::default();
-            self.rps.poc_st_foll = Default::default();
-            self.rps.poc_lt_curr = Default::default();
-            self.rps.poc_lt_foll = Default::default();
+        if slice.nalu().header().nalu_type().is_idr() {
+            self.codec.rps.poc_st_curr_before = Default::default();
+            self.codec.rps.poc_st_curr_after = Default::default();
+            self.codec.rps.poc_st_foll = Default::default();
+            self.codec.rps.poc_lt_curr = Default::default();
+            self.codec.rps.poc_lt_foll = Default::default();
 
-            self.rps.num_poc_st_curr_before = 0;
-            self.rps.num_poc_st_curr_after = 0;
-            self.rps.num_poc_st_foll = 0;
-            self.rps.num_poc_lt_curr = 0;
-            self.rps.num_poc_lt_foll = 0;
+            self.codec.rps.num_poc_st_curr_before = 0;
+            self.codec.rps.num_poc_st_curr_after = 0;
+            self.codec.rps.num_poc_st_foll = 0;
+            self.codec.rps.num_poc_lt_curr = 0;
+            self.codec.rps.num_poc_lt_foll = 0;
         } else {
-            // Equation 8-5
-            let pps = self
-                .parser
-                .get_pps(hdr.pic_parameter_set_id())
-                .context("Invalid SPS in init_current_pic")?;
-
             let sps = self
+                .codec
                 .parser
-                .get_sps(pps.seq_parameter_set_id())
-                .context("Invalid PPS in init_current_pic")?;
+                .get_sps(self.codec.cur_sps_id)
+                .context("Invalid SPS")?;
 
             let curr_st_rps = Self::st_ref_pic_set(hdr, sps);
             let mut j = 0;
@@ -367,31 +422,31 @@ where
                 let poc = cur_pic.pic_order_cnt_val + curr_st_rps.delta_poc_s0()[i];
 
                 if curr_st_rps.used_by_curr_pic_s0()[i] {
-                    self.rps.poc_st_curr_before[j] = poc;
+                    self.codec.rps.poc_st_curr_before[j] = poc;
                     j += 1;
                 } else {
-                    self.rps.poc_st_foll[k] = poc;
+                    self.codec.rps.poc_st_foll[k] = poc;
                     k += 1;
                 }
             }
 
-            self.rps.num_poc_st_curr_before = j as _;
+            self.codec.rps.num_poc_st_curr_before = j as _;
 
             let mut j = 0;
             for i in 0..usize::from(curr_st_rps.num_positive_pics()) {
                 let poc = cur_pic.pic_order_cnt_val + curr_st_rps.delta_poc_s1()[i];
 
                 if curr_st_rps.used_by_curr_pic_s1()[i] {
-                    self.rps.poc_st_curr_after[j] = poc;
+                    self.codec.rps.poc_st_curr_after[j] = poc;
                     j += 1;
                 } else {
-                    self.rps.poc_st_foll[k] = poc;
+                    self.codec.rps.poc_st_foll[k] = poc;
                     k += 1;
                 }
             }
 
-            self.rps.num_poc_st_curr_after = j as _;
-            self.rps.num_poc_st_foll = k as _;
+            self.codec.rps.num_poc_st_curr_after = j as _;
+            self.codec.rps.num_poc_st_foll = k as _;
 
             let mut j = 0;
             let mut k = 0;
@@ -400,128 +455,175 @@ where
                 if hdr.delta_poc_msb_present_flag()[i] {
                     poc_lt += cur_pic.pic_order_cnt_val;
                     let delta_poc =
-                        hdr.delta_poc_msb_cycle_lt()[i] as i32 * self.max_pic_order_cnt_lsb;
+                        hdr.delta_poc_msb_cycle_lt()[i] as i32 * self.codec.max_pic_order_cnt_lsb;
 
                     poc_lt -= delta_poc;
-                    poc_lt -= cur_pic.pic_order_cnt_val & (self.max_pic_order_cnt_lsb - 1);
+                    poc_lt -= cur_pic.pic_order_cnt_val & (self.codec.max_pic_order_cnt_lsb - 1);
                 }
 
                 if hdr.used_by_curr_pic_lt()[i] {
-                    self.rps.poc_lt_curr[j] = poc_lt;
-                    self.rps.curr_delta_poc_msb_present_flag[j] =
+                    self.codec.rps.poc_lt_curr[j] = poc_lt;
+                    self.codec.rps.curr_delta_poc_msb_present_flag[j] =
                         hdr.delta_poc_msb_present_flag()[i];
                     j += 1;
                 } else {
-                    self.rps.poc_lt_foll[k] = poc_lt;
-                    self.rps.foll_delta_poc_msb_present_flag[k] =
+                    self.codec.rps.poc_lt_foll[k] = poc_lt;
+                    self.codec.rps.foll_delta_poc_msb_present_flag[k] =
                         hdr.delta_poc_msb_present_flag()[i];
                     k += 1;
                 }
             }
 
-            self.rps.num_poc_lt_curr = j as _;
-            self.rps.num_poc_lt_foll = k as _;
+            self.codec.rps.num_poc_lt_curr = j as _;
+            self.codec.rps.num_poc_lt_foll = k as _;
         }
 
-        self.derive_and_mark_rps(hdr)?;
+        self.derive_and_mark_rps()?;
         Ok(())
     }
 
     // See the derivation process in the second half of 8.3.2.
-    fn derive_and_mark_rps(&mut self, hdr: &SliceHeader) -> anyhow::Result<()> {
-        let pps = self
-            .parser
-            .get_pps(hdr.pic_parameter_set_id())
-            .context("Invalid SPS in init_current_pic")?;
-
-        let sps = self
-            .parser
-            .get_sps(pps.seq_parameter_set_id())
-            .context("Invalid PPS in init_current_pic")?;
-
-        let max_pic_order_cnt_lsb = 2i32.pow((sps.log2_max_pic_order_cnt_lsb_minus4() + 4).into());
+    fn derive_and_mark_rps(&mut self) -> anyhow::Result<()> {
+        let max_pic_order_cnt_lsb = self.codec.max_pic_order_cnt_lsb;
 
         // Equation 8-6
-        for i in 0..self.rps.num_poc_lt_curr {
-            if !self.rps.curr_delta_poc_msb_present_flag[i] {
-                let poc = self.rps.poc_lt_curr[i] & (max_pic_order_cnt_lsb - 1);
-                self.rps.ref_pic_set_lt_curr[i] = self.dpb.find_ref_by_poc(poc);
+        for i in 0..self.codec.rps.num_poc_lt_curr {
+            if !self.codec.rps.curr_delta_poc_msb_present_flag[i] {
+                let poc = self.codec.rps.poc_lt_curr[i];
+                let mask = max_pic_order_cnt_lsb - 1;
+                let reference = self.codec.dpb.find_ref_by_poc_masked(poc, mask);
+
+                if reference.is_none() {
+                    log::warn!("No reference found for poc {} and mask {}", poc, mask);
+                }
+
+                self.codec.rps.ref_pic_set_lt_curr[i] = reference;
             } else {
-                let poc = self.rps.poc_lt_curr[i];
-                self.rps.ref_pic_set_lt_curr[i] = self.dpb.find_ref_by_poc(poc);
+                let poc = self.codec.rps.poc_lt_curr[i];
+                let reference = self.codec.dpb.find_ref_by_poc(poc);
+
+                if reference.is_none() {
+                    log::warn!("No reference found for poc {}", poc);
+                }
+
+                self.codec.rps.ref_pic_set_lt_curr[i] = reference;
             }
         }
 
-        for i in 0..self.rps.num_poc_lt_foll {
-            if !self.rps.foll_delta_poc_msb_present_flag[i] {
-                let poc = self.rps.poc_lt_foll[i] & (max_pic_order_cnt_lsb - 1);
-                self.rps.ref_pic_set_lt_foll[i] = self.dpb.find_ref_by_poc(poc);
+        for i in 0..self.codec.rps.num_poc_lt_foll {
+            if !self.codec.rps.foll_delta_poc_msb_present_flag[i] {
+                let poc = self.codec.rps.poc_lt_foll[i];
+                let mask = max_pic_order_cnt_lsb - 1;
+                let reference = self.codec.dpb.find_ref_by_poc_masked(poc, mask);
+
+                if reference.is_none() {
+                    log::warn!("No reference found for poc {} and mask {}", poc, mask);
+                }
+
+                self.codec.rps.ref_pic_set_lt_foll[i] = reference;
             } else {
-                let poc = self.rps.poc_lt_foll[i];
-                self.rps.ref_pic_set_lt_foll[i] = self.dpb.find_ref_by_poc(poc);
+                let poc = self.codec.rps.poc_lt_foll[i];
+                let reference = self.codec.dpb.find_ref_by_poc(poc);
+
+                if reference.is_none() {
+                    log::warn!("No reference found for poc {}", poc);
+                }
+
+                self.codec.rps.ref_pic_set_lt_foll[i] = reference;
             }
         }
 
-        for pic in self.rps.ref_pic_set_lt_curr.iter().flatten() {
-            pic.0.borrow_mut().reference = Reference::LongTerm;
+        for pic in self.codec.rps.ref_pic_set_lt_curr.iter().flatten() {
+            pic.0.borrow_mut().set_reference(Reference::LongTerm);
         }
 
-        for pic in self.rps.ref_pic_set_lt_foll.iter().flatten() {
-            pic.0.borrow_mut().reference = Reference::LongTerm;
+        for pic in self.codec.rps.ref_pic_set_lt_foll.iter().flatten() {
+            pic.0.borrow_mut().set_reference(Reference::LongTerm);
         }
 
         // Equation 8-7
-        for i in 0..self.rps.num_poc_st_curr_before {
-            let poc = self.rps.poc_st_curr_before[i];
-            self.rps.ref_pic_set_st_curr_before[i] = self.dpb.find_short_term_ref_by_poc(poc);
+        for i in 0..self.codec.rps.num_poc_st_curr_before {
+            let poc = self.codec.rps.poc_st_curr_before[i];
+            let reference = self.codec.dpb.find_short_term_ref_by_poc(poc);
+
+            if reference.is_none() {
+                log::warn!("No reference found for poc {}", poc);
+            }
+
+            self.codec.rps.ref_pic_set_st_curr_before[i] = reference;
         }
 
-        for i in 0..self.rps.num_poc_st_curr_after {
-            let poc = self.rps.poc_st_curr_after[i];
-            self.rps.ref_pic_set_st_curr_after[i] = self.dpb.find_short_term_ref_by_poc(poc);
+        for i in 0..self.codec.rps.num_poc_st_curr_after {
+            let poc = self.codec.rps.poc_st_curr_after[i];
+            let reference = self.codec.dpb.find_short_term_ref_by_poc(poc);
+
+            if reference.is_none() {
+                log::warn!("No reference found for poc {}", poc);
+            }
+
+            self.codec.rps.ref_pic_set_st_curr_after[i] = reference;
         }
 
-        for i in 0..self.rps.num_poc_st_foll {
-            let poc = self.rps.poc_st_foll[i];
-            self.rps.ref_pic_set_st_foll[i] = self.dpb.find_short_term_ref_by_poc(poc);
+        for i in 0..self.codec.rps.num_poc_st_foll {
+            let poc = self.codec.rps.poc_st_foll[i];
+            let reference = self.codec.dpb.find_short_term_ref_by_poc(poc);
+
+            if reference.is_none() {
+                log::warn!("No reference found for poc {}", poc);
+            }
+
+            self.codec.rps.ref_pic_set_st_foll[i] = reference;
         }
 
         // 4. All reference pictures in the DPB that are not included in
         // RefPicSetLtCurr, RefPicSetLtFoll, RefPicSetStCurrBefore,
         // RefPicSetStCurrAfter, or RefPicSetStFoll and have nuh_layer_id equal
         // to currPicLayerId are marked as "unused for reference"
-        for dpb_pic in self.dpb.entries() {
-            let find_predicate = |p: &Option<DpbEntry<T>>| match p {
+        for dpb_pic in self.codec.dpb.entries() {
+            let find_predicate = |p: &Option<DpbEntry<B::Handle>>| match p {
                 Some(p) => p.0.borrow().pic_order_cnt_val == dpb_pic.0.borrow().pic_order_cnt_val,
                 None => false,
             };
 
-            if !self.rps.ref_pic_set_lt_curr.iter().any(find_predicate)
-                && !self.rps.ref_pic_set_lt_foll.iter().any(find_predicate)
-                && !self
-                    .rps
-                    .ref_pic_set_st_curr_after
+            if !self.codec.rps.ref_pic_set_lt_curr[0..self.codec.rps.num_poc_lt_curr]
+                .iter()
+                .any(find_predicate)
+                && !self.codec.rps.ref_pic_set_lt_foll[0..self.codec.rps.num_poc_lt_foll]
                     .iter()
                     .any(find_predicate)
-                && !self
-                    .rps
-                    .ref_pic_set_st_curr_before
+                && !self.codec.rps.ref_pic_set_st_curr_after
+                    [0..self.codec.rps.num_poc_st_curr_after]
                     .iter()
                     .any(find_predicate)
-                && !self.rps.ref_pic_set_st_foll.iter().any(find_predicate)
+                && !self.codec.rps.ref_pic_set_st_curr_before
+                    [0..self.codec.rps.num_poc_st_curr_before]
+                    .iter()
+                    .any(find_predicate)
+                && !self.codec.rps.ref_pic_set_st_foll[0..self.codec.rps.num_poc_st_foll]
+                    .iter()
+                    .any(find_predicate)
             {
-                dpb_pic.0.borrow_mut().reference = Reference::None;
+                dpb_pic.0.borrow_mut().set_reference(Reference::None);
             }
         }
 
-        let total_rps_len = self.rps.ref_pic_set_lt_curr.iter().count()
-            + self.rps.ref_pic_set_lt_foll.iter().count()
-            + self.rps.ref_pic_set_st_curr_after.iter().count()
-            + self.rps.ref_pic_set_st_curr_before.iter().count()
-            + self.rps.ref_pic_set_st_foll.iter().count();
+        let total_rps_len = self.codec.rps.ref_pic_set_lt_curr[0..self.codec.rps.num_poc_lt_curr]
+            .len()
+            + self.codec.rps.ref_pic_set_lt_foll[0..self.codec.rps.num_poc_lt_foll].len()
+            + self.codec.rps.ref_pic_set_st_curr_after[0..self.codec.rps.num_poc_st_curr_after]
+                .len()
+            + self.codec.rps.ref_pic_set_st_curr_before[0..self.codec.rps.num_poc_st_curr_before]
+                .len()
+            + self.codec.rps.ref_pic_set_st_foll[0..self.codec.rps.num_poc_st_foll].len();
 
-        if self.dpb.entries().len() != total_rps_len {
-            log::warn!("A reference pic is in more than one RPS list. This is against the specification. See 8.3.2. NOTE 5")
+        let dpb_len = self.codec.dpb.entries().len();
+        if dpb_len != total_rps_len {
+            log::warn!(
+                "The total RPS length {} is not the same as the DPB length {}",
+                total_rps_len,
+                dpb_len
+            );
+            log::warn!("A reference pic may be in more than one RPS list. This is against the specification. See 8.3.2. NOTE 5")
         }
 
         // According to Chromium, unavailable reference pictures are handled by
@@ -531,18 +633,37 @@ where
 
     // See 8.3.4.
     // Builds the reference picture list for `hdr` for P and B slices.
-    fn build_ref_pic_lists(&mut self, hdr: &SliceHeader) -> anyhow::Result<()> {
+    fn build_ref_pic_lists(
+        &self,
+        hdr: &SliceHeader,
+        cur_pic: &PictureData,
+    ) -> anyhow::Result<ReferencePicLists<B::Handle>> {
+        let mut ref_pic_lists = ReferencePicLists::default();
+
         // I slices do not use inter prediction.
         if !hdr.type_().is_p() && !hdr.type_().is_b() {
-            return Ok(());
+            return Ok(ref_pic_lists);
         }
 
         let pps = self
+            .codec
             .parser
             .get_pps(hdr.pic_parameter_set_id())
             .context("Invalid PPS in build_ref_pic_lists")?;
 
-        let cur_pic = self.cur_pic.as_ref().unwrap();
+        if self.codec.rps.num_poc_st_curr_before == 0
+            && self.codec.rps.num_poc_st_curr_after == 0
+            && self.codec.rps.num_poc_lt_curr == 0
+            && pps.scc_extension_flag()
+            && !pps.scc_extension().curr_pic_ref_enabled_flag()
+        {
+            // Let's try and keep going, if it is a broken stream then maybe it
+            // will sort itself out as we go. In any case, we must not loop
+            // infinitely here.
+            log::error!("Bug or broken stream: out of pictures and can't build ref pic lists.");
+            return Ok(ref_pic_lists);
+        }
+
         let rplm = hdr.ref_pic_list_modification();
 
         let num_rps_curr_temp_list0 = std::cmp::max(
@@ -552,37 +673,38 @@ where
 
         // This could be simplified using a Vec, but lets not change the
         // algorithm from the spec too much.
-        let mut ref_pic_list_temp0: [Option<RefPicListEntry<T>>; MAX_DPB_SIZE] = Default::default();
+        let mut ref_pic_list_temp0: [Option<RefPicListEntry<B::Handle>>; MAX_DPB_SIZE] =
+            Default::default();
 
         // Equation 8-8
         let mut r_idx = 0;
         assert!(num_rps_curr_temp_list0 as usize <= MAX_DPB_SIZE);
         while r_idx < num_rps_curr_temp_list0 {
             let mut i = 0;
-            while i < self.rps.num_poc_st_curr_before && r_idx < num_rps_curr_temp_list0 {
-                ref_pic_list_temp0[r_idx as usize] = self.rps.ref_pic_set_st_curr_before[i]
+            while i < self.codec.rps.num_poc_st_curr_before && r_idx < num_rps_curr_temp_list0 {
+                ref_pic_list_temp0[r_idx as usize] = self.codec.rps.ref_pic_set_st_curr_before[i]
                     .clone()
-                    .map(|e| RefPicListEntry::DpbEntry(e));
+                    .map(RefPicListEntry::DpbEntry);
 
                 i += 1;
                 r_idx += 1;
             }
 
             let mut i = 0;
-            while i < self.rps.num_poc_st_curr_after && r_idx < num_rps_curr_temp_list0 {
-                ref_pic_list_temp0[r_idx as usize] = self.rps.ref_pic_set_st_curr_after[i]
+            while i < self.codec.rps.num_poc_st_curr_after && r_idx < num_rps_curr_temp_list0 {
+                ref_pic_list_temp0[r_idx as usize] = self.codec.rps.ref_pic_set_st_curr_after[i]
                     .clone()
-                    .map(|e| RefPicListEntry::DpbEntry(e));
+                    .map(RefPicListEntry::DpbEntry);
 
                 i += 1;
                 r_idx += 1;
             }
 
             let mut i = 0;
-            while i < self.rps.num_poc_lt_curr && r_idx < num_rps_curr_temp_list0 {
-                ref_pic_list_temp0[r_idx as usize] = self.rps.ref_pic_set_lt_curr[i]
+            while i < self.codec.rps.num_poc_lt_curr && r_idx < num_rps_curr_temp_list0 {
+                ref_pic_list_temp0[r_idx as usize] = self.codec.rps.ref_pic_set_lt_curr[i]
                     .clone()
-                    .map(|e| RefPicListEntry::DpbEntry(e));
+                    .map(RefPicListEntry::DpbEntry);
 
                 i += 1;
                 r_idx += 1;
@@ -605,19 +727,19 @@ where
                 ref_pic_list_temp0[r_idx].clone()
             };
 
-            self.ref_pic_list0[r_idx] = entry;
+            ref_pic_lists.ref_pic_list0[r_idx] = entry;
         }
 
         if pps.scc_extension().curr_pic_ref_enabled_flag()
             && !rplm.ref_pic_list_modification_flag_l0()
             && num_rps_curr_temp_list0 > (u32::from(hdr.num_ref_idx_l0_active_minus1()) + 1)
         {
-            self.ref_pic_list0[r_idx as usize] =
+            ref_pic_lists.ref_pic_list0[r_idx as usize] =
                 Some(RefPicListEntry::CurrentPicture(cur_pic.clone()));
         }
 
         if hdr.type_().is_b() {
-            let mut ref_pic_list_temp1: [Option<RefPicListEntry<T>>; MAX_DPB_SIZE] =
+            let mut ref_pic_list_temp1: [Option<RefPicListEntry<B::Handle>>; MAX_DPB_SIZE] =
                 Default::default();
 
             let num_rps_curr_temp_list1 = std::cmp::max(
@@ -630,28 +752,30 @@ where
             assert!(num_rps_curr_temp_list1 as usize <= MAX_DPB_SIZE);
             while r_idx < num_rps_curr_temp_list1 {
                 let mut i = 0;
-                while i < self.rps.num_poc_st_curr_after && r_idx < num_rps_curr_temp_list1 {
-                    ref_pic_list_temp1[r_idx as usize] = self.rps.ref_pic_set_st_curr_after[i]
+                while i < self.codec.rps.num_poc_st_curr_after && r_idx < num_rps_curr_temp_list1 {
+                    ref_pic_list_temp1[r_idx as usize] = self.codec.rps.ref_pic_set_st_curr_after
+                        [i]
                         .clone()
-                        .map(|e| RefPicListEntry::DpbEntry(e));
+                        .map(RefPicListEntry::DpbEntry);
                     i += 1;
                     r_idx += 1;
                 }
 
                 let mut i = 0;
-                while i < self.rps.num_poc_st_curr_before && r_idx < num_rps_curr_temp_list1 {
-                    ref_pic_list_temp1[r_idx as usize] = self.rps.ref_pic_set_st_curr_before[i]
+                while i < self.codec.rps.num_poc_st_curr_before && r_idx < num_rps_curr_temp_list1 {
+                    ref_pic_list_temp1[r_idx as usize] = self.codec.rps.ref_pic_set_st_curr_before
+                        [i]
                         .clone()
-                        .map(|e| RefPicListEntry::DpbEntry(e));
+                        .map(RefPicListEntry::DpbEntry);
                     i += 1;
                     r_idx += 1;
                 }
 
                 let mut i = 0;
-                while i < self.rps.num_poc_lt_curr && r_idx < num_rps_curr_temp_list1 {
-                    ref_pic_list_temp1[r_idx as usize] = self.rps.ref_pic_set_lt_curr[i]
+                while i < self.codec.rps.num_poc_lt_curr && r_idx < num_rps_curr_temp_list1 {
+                    ref_pic_list_temp1[r_idx as usize] = self.codec.rps.ref_pic_set_lt_curr[i]
                         .clone()
-                        .map(|e| RefPicListEntry::DpbEntry(e));
+                        .map(RefPicListEntry::DpbEntry);
                     i += 1;
                     r_idx += 1;
                 }
@@ -673,52 +797,78 @@ where
                     ref_pic_list_temp1[r_idx].clone()
                 };
 
-                self.ref_pic_list1[r_idx] = entry;
+                ref_pic_lists.ref_pic_list1[r_idx] = entry;
             }
         }
+
+        Ok(ref_pic_lists)
+    }
+
+    /// Drain the decoder, processing all pending frames.
+    fn drain(&mut self) -> anyhow::Result<()> {
+        log::debug!("Draining the decoder");
+
+        // Finish the current picture if there is one pending.
+        if let Some(cur_pic) = self.codec.current_pic.take() {
+            self.finish_picture(cur_pic)?;
+        }
+
+        let pics = self.codec.dpb.drain();
+
+        log::debug!(
+            "Adding POCs {:?} to the ready queue while draining",
+            pics.iter()
+                .map(|p| p.0.borrow().pic_order_cnt_val)
+                .collect::<Vec<_>>()
+        );
+
+        log::trace!(
+            "{:#?}",
+            pics.iter().map(|p| p.0.borrow()).collect::<Vec<_>>()
+        );
+
+        self.ready_queue.extend(pics.into_iter().map(|h| h.1));
+        self.codec.dpb.clear();
 
         Ok(())
     }
 
-    /// Drain the decoder, processing all pending frames.
-    fn drain(&mut self) {
-        let pics = self.dpb.drain();
-
-        self.ready_queue.extend(pics.into_iter().map(|h| h.1));
-
-        self.dpb.clear();
-    }
-
     fn clear_ref_lists(&mut self) {
-        self.ref_pic_list0 = Default::default();
-        self.ref_pic_list1 = Default::default();
-        self.rps.ref_pic_set_lt_curr = Default::default();
-        self.rps.ref_pic_set_st_curr_after = Default::default();
-        self.rps.ref_pic_set_st_curr_before = Default::default();
+        if let Some(pic) = self.codec.current_pic.as_mut() {
+            pic.ref_pic_lists = Default::default();
+        }
 
-        self.rps.num_poc_lt_curr = Default::default();
-        self.rps.num_poc_lt_foll = Default::default();
-        self.rps.num_poc_st_curr_after = Default::default();
-        self.rps.num_poc_st_curr_before = Default::default();
-        self.rps.num_poc_st_foll = Default::default();
+        self.codec.rps.ref_pic_set_lt_curr = Default::default();
+        self.codec.rps.ref_pic_set_st_curr_after = Default::default();
+        self.codec.rps.ref_pic_set_st_curr_before = Default::default();
+
+        self.codec.rps.num_poc_lt_curr = Default::default();
+        self.codec.rps.num_poc_lt_foll = Default::default();
+        self.codec.rps.num_poc_st_curr_after = Default::default();
+        self.codec.rps.num_poc_st_curr_before = Default::default();
+        self.codec.rps.num_poc_st_foll = Default::default();
     }
 
     /// Bumps the DPB if needed.
-    fn bump_as_needed(&mut self, bumping_type: BumpingType) -> anyhow::Result<Vec<DpbEntry<T>>> {
+    fn bump_as_needed(
+        &mut self,
+        bumping_type: BumpingType,
+    ) -> anyhow::Result<Vec<DpbEntry<B::Handle>>> {
         let mut pics = vec![];
 
-        let sps = self
-            .parser
-            .get_sps(self.cur_sps_id)
-            .context("Invalid SPS in bump_as_needed")?;
-
         let needs_bumping = match bumping_type {
-            BumpingType::BeforeDecoding => Dpb::<T>::needs_bumping,
-            BumpingType::AfterDecoding => Dpb::<T>::needs_additional_bumping,
+            BumpingType::BeforeDecoding => Dpb::<B::Handle>::needs_bumping,
+            BumpingType::AfterDecoding => Dpb::<B::Handle>::needs_additional_bumping,
         };
 
-        while needs_bumping(&mut self.dpb, sps) {
-            match self.dpb.bump(false) {
+        let sps = self
+            .codec
+            .parser
+            .get_sps(self.codec.cur_sps_id)
+            .context("Invalid SPS id")?;
+
+        while needs_bumping(&mut self.codec.dpb, sps) {
+            match self.codec.dpb.bump(false) {
                 Some(pic) => pics.push(pic),
                 None => return Ok(pics),
             }
@@ -728,273 +878,359 @@ where
     }
 
     // See C.5.2.2
-    fn update_dpb_before_decoding(&mut self) -> anyhow::Result<()> {
-        let cur_pic = self.cur_pic.as_ref().unwrap();
-
-        if cur_pic.is_irap && cur_pic.no_rasl_output_flag && !cur_pic.is_first_picture {
+    fn update_dpb_before_decoding(&mut self, cur_pic: &PictureData) -> anyhow::Result<()> {
+        if cur_pic.is_irap && cur_pic.no_rasl_output_flag && !self.codec.first_picture_after_eos {
             if cur_pic.no_output_of_prior_pics_flag {
-                self.dpb.clear();
+                self.codec.dpb.clear();
             } else {
-                self.drain();
+                self.drain()?;
             }
         } else {
-            self.dpb.remove_unused();
-            let bumped = self
-                .bump_as_needed(BumpingType::BeforeDecoding)?
-                .into_iter()
-                .map(|p| p.1)
-                .collect::<Vec<_>>();
+            self.codec.dpb.remove_unused();
+            let bumped = self.bump_as_needed(BumpingType::BeforeDecoding)?;
+
+            log::debug!(
+                "Adding POCs {:?} to the ready queue before decoding",
+                bumped
+                    .iter()
+                    .map(|p| p.0.borrow().pic_order_cnt_val)
+                    .collect::<Vec<_>>()
+            );
+
+            log::trace!(
+                "{:#?}",
+                bumped.iter().map(|p| p.0.borrow()).collect::<Vec<_>>()
+            );
+
+            let bumped = bumped.into_iter().map(|p| p.1).collect::<Vec<_>>();
             self.ready_queue.extend(bumped);
         }
 
         Ok(())
     }
 
-    /// Handle a picture. Called only once per frame.
-    fn handle_picture(&mut self, timestamp: u64, slice: &Slice<&[u8]>) -> anyhow::Result<()> {
-        let prev_tid0 = self.prev_tid_0_pic.as_ref();
-
-        let pps = self
-            .parser
-            .get_pps(slice.header().pic_parameter_set_id())
-            .context("Invalid PPS in handle_picture")?;
-
-        let _sps = self
-            .parser
-            .get_sps(pps.seq_parameter_set_id())
-            .context("Invalid SPS in handle_picture")?;
-
-        self.cur_pps_id = pps.pic_parameter_set_id();
-        self.cur_sps_id = pps.seq_parameter_set_id();
-        self.cur_pic = Some(PictureData::new_from_slice(
-            slice,
-            pps,
-            self.is_first_picture_in_au,
-            prev_tid0,
-            self.max_pic_order_cnt_lsb,
-            timestamp,
-        ));
-
-        let cur_pic = self.cur_pic.as_ref().unwrap();
-        log::debug!("Decode picture POC {:?}", cur_pic.pic_order_cnt_val);
-
-        self.decode_rps(slice)?;
-        self.update_dpb_before_decoding()?;
-
-        let cur_pic = self.cur_pic.as_ref().unwrap();
-
-        let mut cur_backend_pic = self.backend.new_picture(cur_pic, timestamp)?;
-
-        self.backend.handle_picture(
-            &mut cur_backend_pic,
-            cur_pic,
-            self.parser
-                .get_sps(self.cur_sps_id)
-                .context("Invalid SPS in handle_picture")?,
-            self.parser
-                .get_pps(self.cur_pps_id)
-                .context("Invalid PPS in handle_picture")?,
-            &self.dpb,
-            &self.rps,
-            slice,
-        )?;
-
-        self.cur_backend_pic = Some(cur_backend_pic);
-        Ok(())
-    }
-
-    /// Handle a slice. Called once per slice NALU.
-    fn handle_slice(&mut self, _timestamp: u64, slice: &Slice<&[u8]>) -> anyhow::Result<()> {
-        self.build_ref_pic_lists(slice.header())?;
-
-        self.backend.decode_slice(
-            self.cur_backend_pic.as_mut().unwrap(),
-            slice,
-            self.parser
-                .get_sps(self.cur_sps_id)
-                .context("Invalid SPS in handle_slice")?,
-            self.parser
-                .get_pps(self.cur_pps_id)
-                .context("Invalid PPS in handle_slice")?,
-            &self.dpb,
-            &self.ref_pic_list0,
-            &self.ref_pic_list1,
-        )?;
-
-        Ok(())
-    }
-
-    fn finish_picture(&mut self, pic: PictureData, handle: T) -> anyhow::Result<()> {
-        log::debug!("Finishing picture POC {:?}", pic.pic_order_cnt_val);
-
-        // 8.3.1
-        if pic.valid_for_prev_tid0_pic {
-            self.prev_tid_0_pic = Some(pic.clone());
-        }
-
-        self.clear_ref_lists();
-
-        let bumped = self
-            .bump_as_needed(BumpingType::AfterDecoding)?
-            .into_iter()
-            .map(|p| p.1)
-            .collect::<Vec<_>>();
-        self.ready_queue.extend(bumped);
-
-        self.dpb.store_picture(Rc::new(RefCell::new(pic)), handle)?;
-        Ok(())
-    }
-
-    fn decode_access_unit(
+    /// Called once per picture to start it.
+    fn begin_picture(
         &mut self,
         timestamp: u64,
-        bitstream: &[u8],
-    ) -> Result<usize, DecodeError> {
+        slice: &Slice<&[u8]>,
+    ) -> Result<Option<CurrentPicState<B>>, DecodeError> {
         if self.backend.surface_pool().num_free_surfaces() == 0 {
             return Err(DecodeError::NotEnoughOutputBuffers(1));
         }
 
-        let mut cursor = Cursor::new(bitstream);
+        let pps = self
+            .codec
+            .parser
+            .get_pps(slice.header().pic_parameter_set_id())
+            .context("Invalid PPS in handle_picture")?;
 
-        while let Ok(nalu) = Nalu::next(&mut cursor) {
-            match nalu.header().type_() {
-                NaluType::VpsNut => {
-                    self.parser.parse_vps(&nalu)?;
-                }
-                NaluType::SpsNut => {
-                    self.parser.parse_sps(&nalu)?;
+        let pps_id = pps.pic_parameter_set_id();
+        self.update_current_set_ids(pps_id)?;
+        self.renegotiate_if_needed(RenegotiationType::CurrentSps)?;
+
+        // We renegotiated and must return the NALU and wait.
+        if matches!(self.decoding_state, DecodingState::AwaitingFormat(_)) {
+            return Err(DecodeError::CheckEvents);
+        }
+
+        let pic = PictureData::new_from_slice(
+            slice,
+            self.codec
+                .parser
+                .get_pps(self.codec.cur_pps_id)
+                .context("Invalid PPS")?,
+            self.codec.first_picture_in_bitstream,
+            self.codec.first_picture_after_eos,
+            self.codec.prev_tid_0_pic.as_ref(),
+            self.codec.max_pic_order_cnt_lsb,
+            timestamp,
+        );
+
+        self.codec.first_picture_after_eos = false;
+        self.codec.first_picture_in_bitstream = false;
+
+        if pic.is_irap {
+            self.codec.irap_no_rasl_output_flag = pic.no_rasl_output_flag;
+        } else if pic.nalu_type.is_rasl() && self.codec.irap_no_rasl_output_flag {
+            // NOTE – All RASL pictures are leading pictures of an associated
+            // BLA or CRA picture. When the associated IRAP picture has
+            // NoRaslOutputFlag equal to 1, the RASL picture is not output and
+            // may not be correctly decodable, as the RASL picture may contain
+            // references to pictures that are not present in the bitstream.
+            // RASL pictures are not used as reference pictures for the decoding
+            // process of non-RASL pictures.
+            log::debug!(
+                "Dropping POC {}, as it may not be decodable according to the specification",
+                pic.pic_order_cnt_val
+            );
+
+            return Ok(None);
+        }
+
+        log::debug!("Decode picture POC {}", pic.pic_order_cnt_val);
+
+        self.decode_rps(slice, &pic)?;
+        self.update_dpb_before_decoding(&pic)?;
+
+        let mut backend_pic = self.backend.new_picture(&pic, timestamp)?;
+
+        self.backend.begin_picture(
+            &mut backend_pic,
+            &pic,
+            self.codec
+                .parser
+                .get_sps(self.codec.cur_sps_id)
+                .context("Invalid SPS")?,
+            self.codec
+                .parser
+                .get_pps(self.codec.cur_pps_id)
+                .context("Invalid PPS")?,
+            &self.codec.dpb,
+            &self.codec.rps,
+            slice,
+        )?;
+
+        Ok(Some(CurrentPicState {
+            pic,
+            backend_pic,
+            ref_pic_lists: Default::default(),
+        }))
+    }
+
+    fn update_current_set_ids(&mut self, pps_id: u8) -> anyhow::Result<()> {
+        let pps = self.codec.parser.get_pps(pps_id).context("Invalid PPS")?;
+
+        self.codec.cur_pps_id = pps.pic_parameter_set_id();
+        self.codec.cur_sps_id = pps.seq_parameter_set_id();
+        Ok(())
+    }
+
+    /// Handle a slice. Called once per slice NALU.
+    fn handle_slice(
+        &mut self,
+        pic: &mut CurrentPicState<B>,
+        slice: &Slice<&[u8]>,
+    ) -> anyhow::Result<()> {
+        // A dependent slice may refer to a previous SPS which
+        // is not the one currently in use.
+        self.update_current_set_ids(slice.header().pic_parameter_set_id())?;
+
+        let sps = self
+            .codec
+            .parser
+            .get_sps(self.codec.cur_sps_id)
+            .context("Invalid SPS")?;
+
+        // Make sure that no negotiation is possible mid-picture. How could it?
+        // We'd lose the context with the previous slices on it.
+        assert!(!Self::negotiation_possible(
+            sps,
+            &self.codec.dpb,
+            &self.codec.negotiation_info,
+        ));
+
+        pic.ref_pic_lists = self.build_ref_pic_lists(slice.header(), &pic.pic)?;
+
+        self.backend.decode_slice(
+            &mut pic.backend_pic,
+            slice,
+            self.codec
+                .parser
+                .get_sps(self.codec.cur_sps_id)
+                .context("Invalid SPS id")?,
+            self.codec
+                .parser
+                .get_pps(self.codec.cur_pps_id)
+                .context("Invalid PPS id")?,
+            &self.codec.dpb,
+            &pic.ref_pic_lists.ref_pic_list0,
+            &pic.ref_pic_lists.ref_pic_list1,
+        )?;
+
+        Ok(())
+    }
+
+    fn finish_picture(&mut self, pic: CurrentPicState<B>) -> anyhow::Result<()> {
+        log::debug!("Finishing picture POC {:?}", pic.pic.pic_order_cnt_val);
+
+        // Submit the picture to the backend.
+        let handle = self.submit_picture(pic.backend_pic)?;
+        let pic = pic.pic;
+
+        // 8.3.1
+        if pic.valid_for_prev_tid0_pic {
+            self.codec.prev_tid_0_pic = Some(pic.clone());
+        }
+
+        self.clear_ref_lists();
+
+        // First store the current picture in the DPB, only then we should
+        // decide whether to bump.
+        self.codec
+            .dpb
+            .store_picture(Rc::new(RefCell::new(pic)), handle)?;
+        let bumped = self.bump_as_needed(BumpingType::AfterDecoding)?;
+
+        log::debug!(
+            "Adding POCs {:?} to the ready queue after decoding",
+            bumped
+                .iter()
+                .map(|p| p.0.borrow().pic_order_cnt_val)
+                .collect::<Vec<_>>()
+        );
+
+        log::trace!(
+            "{:#?}",
+            bumped.iter().map(|p| p.0.borrow()).collect::<Vec<_>>()
+        );
+
+        let bumped = bumped.into_iter().map(|p| p.1).collect::<Vec<_>>();
+        self.ready_queue.extend(bumped);
+
+        Ok(())
+    }
+
+    fn renegotiate_if_needed(
+        &mut self,
+        renegotiation_type: RenegotiationType,
+    ) -> anyhow::Result<()> {
+        let sps = match renegotiation_type {
+            RenegotiationType::CurrentSps => self
+                .codec
+                .parser
+                .get_sps(self.codec.cur_sps_id)
+                .context("Invalid SPS")?,
+            RenegotiationType::NewSps(sps) => sps,
+        };
+
+        if Self::negotiation_possible(sps, &self.codec.dpb, &self.codec.negotiation_info) {
+            // Make sure all the frames we decoded so far are in the ready queue.
+            self.drain()?;
+            let sps = match renegotiation_type {
+                RenegotiationType::CurrentSps => self
+                    .codec
+                    .parser
+                    .get_sps(self.codec.cur_sps_id)
+                    .context("Invalid SPS")?,
+                RenegotiationType::NewSps(sps) => sps,
+            };
+            self.backend.new_sequence(sps)?;
+            self.decoding_state = DecodingState::AwaitingFormat(sps.clone());
+        }
+
+        Ok(())
+    }
+
+    fn process_nalu(&mut self, timestamp: u64, nalu: Nalu<&[u8]>) -> Result<(), DecodeError> {
+        log::debug!(
+            "Processing NALU {:?}, length is {}",
+            nalu.header().nalu_type(),
+            nalu.size()
+        );
+
+        match nalu.header().nalu_type() {
+            NaluType::VpsNut => {
+                self.codec.parser.parse_vps(&nalu)?;
+            }
+            NaluType::SpsNut => {
+                let sps = self.codec.parser.parse_sps(&nalu)?;
+                self.codec.max_pic_order_cnt_lsb =
+                    1 << (sps.log2_max_pic_order_cnt_lsb_minus4() + 4);
+            }
+
+            NaluType::PpsNut => {
+                self.codec.parser.parse_pps(&nalu)?;
+            }
+
+            NaluType::BlaWLp
+            | NaluType::BlaWRadl
+            | NaluType::BlaNLp
+            | NaluType::IdrWRadl
+            | NaluType::IdrNLp
+            | NaluType::TrailN
+            | NaluType::TrailR
+            | NaluType::TsaN
+            | NaluType::TsaR
+            | NaluType::StsaN
+            | NaluType::StsaR
+            | NaluType::RadlN
+            | NaluType::RadlR
+            | NaluType::RaslN
+            | NaluType::RaslR
+            | NaluType::CraNut => {
+                let mut slice = self.codec.parser.parse_slice_header(nalu)?;
+
+                let first_slice_segment_in_pic_flag =
+                    slice.header().first_slice_segment_in_pic_flag();
+
+                if slice.header().dependent_slice_segment_flag() {
+                    let previous_independent_header = self.codec.last_independent_slice_header.as_ref().ok_or(anyhow!("Cannot process an dependent slice without first processing and independent one"))?.clone();
+                    slice.replace_header(previous_independent_header)?;
+                } else {
+                    self.codec.last_independent_slice_header = Some(slice.header().clone());
                 }
 
-                NaluType::PpsNut => {
-                    self.parser.parse_pps(&nalu)?;
-                }
-
-                NaluType::BlaWLp
-                | NaluType::BlaWRadl
-                | NaluType::BlaNLp
-                | NaluType::IdrWRadl
-                | NaluType::IdrNLp
-                | NaluType::TrailN
-                | NaluType::TrailR
-                | NaluType::TsaN
-                | NaluType::TsaR
-                | NaluType::StsaN
-                | NaluType::StsaR
-                | NaluType::RadlN
-                | NaluType::RadlR
-                | NaluType::RaslN
-                | NaluType::RaslR
-                | NaluType::CraNut => {
-                    if matches!(self.decoding_state, DecodingState::AwaitingFormat(_)) {
-                        // If we have a forced a renegotiation when processing a
-                        // dependent slice, skip any further slices of this picture.
-                        // TODO: How are we giving back the NALUs so that the client can retry?
-                        continue;
+                let cur_pic = match self.codec.current_pic.take() {
+                    // No current picture, start a new one.
+                    None => self.begin_picture(timestamp, &slice)?,
+                    Some(cur_pic) if first_slice_segment_in_pic_flag => {
+                        self.finish_picture(cur_pic)?;
+                        self.begin_picture(timestamp, &slice)?
                     }
+                    Some(cur_pic) => Some(cur_pic),
+                };
 
-                    let mut slice = self.parser.parse_slice_header(nalu)?;
-
-                    let first_slice_segment_in_pic_flag =
-                        slice.header().first_slice_segment_in_pic_flag();
-
-                    if slice.header().dependent_slice_segment_flag() {
-                        let previous_independent_header = self.last_independent_slice_header.as_ref().ok_or(anyhow!("Cannot process an dependent slice without first processing and independent one"))?.clone();
-                        slice.replace_header(previous_independent_header)?;
-
-                        let pps = self
-                            .parser
-                            .get_pps(slice.header().pic_parameter_set_id())
-                            .context("Invalid SPS when processing a dependent slice")?;
-
-                        let sps = self
-                            .parser
-                            .get_sps(pps.seq_parameter_set_id())
-                            .context("Invalid PPS when processing a dependent slice")?;
-
-                        // A dependent slice may refer to a previous SPS which
-                        // is not the one currently in use.
-                        if Self::negotiation_possible(sps, &self.dpb, &self.negotiation_info) {
-                            self.backend.new_sequence(sps)?;
-                            self.decoding_state = DecodingState::AwaitingFormat(sps.clone());
-                            continue;
-                        }
-                    } else {
-                        self.last_independent_slice_header = Some(slice.header().clone());
-                    }
-
-                    if self.cur_pic.is_none() {
-                        if self.backend.surface_pool().num_free_surfaces() == 0 {
-                            return Err(DecodeError::NotEnoughOutputBuffers(1));
-                        }
-
-                        self.handle_picture(timestamp, &slice)?;
-                    } else if first_slice_segment_in_pic_flag {
-                        // We have identified a new picture and must submit the
-                        // old one before proceeding.
-                        let (picture, handle) = self.submit_picture()?;
-                        self.finish_picture(picture, handle)?;
-
-                        // TODO: the right place to check is before starting a
-                        // picture, all other operations do not consume
-                        // resources from the backend. Maybe we should backport
-                        // this idea to h.264, as it will also crash if enough
-                        // slices make this path be taken too much, which means
-                        // that the client would not receive
-                        // DecodeError::CheckEvents (in h264's implementation),
-                        // but rather "OutOfResources" from the backend, which
-                        // will abort ccdec.
-                        if self.backend.surface_pool().num_free_surfaces() == 0 {
-                            return Err(DecodeError::NotEnoughOutputBuffers(1));
-                        }
-
-                        self.handle_picture(timestamp, &slice)?;
-                    }
-
-                    self.handle_slice(timestamp, &slice)?;
+                // Picture may have been dropped during begin_picture()
+                if let Some(mut cur_pic) = cur_pic {
+                    self.handle_slice(&mut cur_pic, &slice)?;
+                    self.codec.current_pic = Some(cur_pic);
                 }
+            }
 
-                NaluType::EosNut => {
-                    self.is_first_picture_in_au = true;
-                }
-                other => {
-                    log::debug!("Unsupported NAL unit type {:?}", other,);
-                }
+            NaluType::EosNut => {
+                self.codec.first_picture_after_eos = true;
+            }
+
+            NaluType::EobNut => {
+                self.codec.first_picture_in_bitstream = true;
+            }
+
+            other => {
+                log::debug!("Unsupported NAL unit type {:?}", other,);
             }
         }
 
-        let (picture, handle) = self.submit_picture()?;
-        self.finish_picture(picture, handle)?;
-
-        Ok(bitstream.len())
+        Ok(())
     }
 
     /// Submits the picture to the accelerator.
-    fn submit_picture(&mut self) -> Result<(PictureData, T), DecodeError> {
-        let picture = self.cur_pic.take().unwrap();
-
-        let handle = self
-            .backend
-            .submit_picture(self.cur_backend_pic.take().unwrap())?;
+    fn submit_picture(&mut self, backend_pic: B::Picture) -> Result<B::Handle, DecodeError> {
+        let handle = self.backend.submit_picture(backend_pic)?;
 
         if self.blocking_mode == BlockingMode::Blocking {
             handle.sync()?;
         }
 
-        Ok((picture, handle))
+        Ok(handle)
     }
 }
 
-impl<T, P> StatelessVideoDecoder<T::Descriptor> for Decoder<T, P>
+impl<B> StatelessVideoDecoder<<B::Handle as DecodedHandle>::Descriptor>
+    for StatelessDecoder<H265, B>
 where
-    T: DecodedHandle + Clone + 'static,
+    B: StatelessH265DecoderBackend,
+    B::Handle: Clone + 'static,
 {
-    fn decode(&mut self, timestamp: u64, mut bitstream: &[u8]) -> Result<usize, DecodeError> {
-        let sps = Self::peek_sps(&mut self.parser, bitstream)?;
+    fn decode(&mut self, timestamp: u64, bitstream: &[u8]) -> Result<usize, DecodeError> {
+        let mut cursor = Cursor::new(bitstream);
+        let nalu = Nalu::next(&mut cursor)?;
 
-        if let Some(sps) = sps {
-            if Self::negotiation_possible(&sps, &self.dpb, &self.negotiation_info) {
-                self.backend.new_sequence(&sps)?;
-                self.decoding_state = DecodingState::AwaitingFormat(sps);
+        if nalu.header().nalu_type() == NaluType::SpsNut {
+            let sps = self.codec.parser.parse_sps(&nalu)?.clone();
+            if matches!(self.decoding_state, DecodingState::AwaitingStreamInfo) {
+                // If more SPS come along we will renegotiate in begin_picture().
+                self.renegotiate_if_needed(RenegotiationType::NewSps(&sps))?;
             } else if matches!(self.decoding_state, DecodingState::Reset) {
                 // We can resume decoding since the decoding parameters have not changed.
                 self.decoding_state = DecodingState::Decoding;
@@ -1004,31 +1240,41 @@ where
 
             while let Ok(nalu) = Nalu::next(&mut cursor) {
                 // In the Reset state we can resume decoding from any key frame.
-                if nalu.header().type_().is_idr() {
-                    bitstream = &bitstream[nalu.sc_offset()..];
+                if nalu.header().nalu_type().is_idr() {
                     self.decoding_state = DecodingState::Decoding;
                     break;
                 }
             }
         }
 
+        let nalu_len = nalu.offset() + nalu.size();
+
         match &mut self.decoding_state {
-            // Skip input until we get information from the stream.
-            DecodingState::AwaitingStreamInfo | DecodingState::Reset => Ok(bitstream.len()),
+            // Process VPS, but skip input until we get information from the
+            // stream.
+            DecodingState::AwaitingStreamInfo | DecodingState::Reset => {
+                if nalu.header().nalu_type() == NaluType::VpsNut {
+                    self.process_nalu(timestamp, nalu)?;
+                }
+            }
             // Ask the client to confirm the format before we can process this.
-            DecodingState::AwaitingFormat(_) => Err(DecodeError::CheckEvents),
-            DecodingState::Decoding => self.decode_access_unit(timestamp, bitstream),
+            DecodingState::AwaitingFormat(_) => return Err(DecodeError::CheckEvents),
+            DecodingState::Decoding => {
+                self.process_nalu(timestamp, nalu)?;
+            }
         }
+
+        Ok(nalu_len)
     }
 
     fn flush(&mut self) -> Result<(), DecodeError> {
-        self.drain();
+        self.drain()?;
         self.decoding_state = DecodingState::Reset;
 
         Ok(())
     }
 
-    fn next_event(&mut self) -> Option<DecoderEvent<T::Descriptor>> {
+    fn next_event(&mut self) -> Option<DecoderEvent<<B::Handle as DecodedHandle>::Descriptor>> {
         // The next event is either the next frame, or, if we are awaiting negotiation, the format
         // change event that will allow us to keep going.
         (&mut self.ready_queue)
@@ -1040,7 +1286,8 @@ where
                         StatelessDecoderFormatNegotiator::new(self, sps.clone(), |decoder, sps| {
                             // Apply the SPS settings to the decoder so we don't enter the AwaitingFormat state
                             // on the next decode() call.
-                            decoder.apply_sps(sps);
+                            // TODO: unwrap this for now, but ideally change this closure to return Result
+                            decoder.apply_sps(sps).unwrap();
                             decoder.decoding_state = DecodingState::Decoding;
                         }),
                     )))
@@ -1050,7 +1297,7 @@ where
             })
     }
 
-    fn surface_pool(&mut self) -> &mut dyn SurfacePool<T::Descriptor> {
+    fn surface_pool(&mut self) -> &mut dyn SurfacePool<<B::Handle as DecodedHandle>::Descriptor> {
         self.backend.surface_pool()
     }
 
@@ -1059,26 +1306,13 @@ where
     }
 }
 
-impl<T, P> private::StatelessVideoDecoder for Decoder<T, P>
-where
-    T: DecodedHandle + Clone,
-{
-    fn try_format(&mut self, format: crate::DecodedFormat) -> anyhow::Result<()> {
-        match &self.decoding_state {
-            DecodingState::AwaitingFormat(sps) => self.backend.try_format(sps, format),
-            _ => Err(anyhow!(
-                "current decoder state does not allow format change"
-            )),
-        }
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
 
-    use crate::decoder::stateless::h265::Decoder;
+    use crate::decoder::stateless::h265::H265;
     use crate::decoder::stateless::tests::test_decode_stream;
     use crate::decoder::stateless::tests::TestStream;
+    use crate::decoder::stateless::StatelessDecoder;
     use crate::decoder::BlockingMode;
     use crate::utils::simple_playback_loop;
     use crate::utils::simple_playback_loop_owned_surfaces;
@@ -1087,7 +1321,7 @@ pub mod tests {
 
     /// Run `test` using the dummy decoder, in both blocking and non-blocking modes.
     fn test_decoder_dummy(test: &TestStream, blocking_mode: BlockingMode) {
-        let decoder = Decoder::new_dummy(blocking_mode).unwrap();
+        let decoder = StatelessDecoder::<H265, _>::new_dummy(blocking_mode);
 
         test_decode_stream(
             |d, s, f| {

--- a/src/decoder/stateless/h265/dummy.rs
+++ b/src/decoder/stateless/h265/dummy.rs
@@ -10,7 +10,8 @@ use std::rc::Rc;
 
 use crate::backend::dummy::Backend;
 use crate::backend::dummy::Handle;
-use crate::decoder::stateless::h265::Decoder;
+use crate::decoder::stateless::h265::H265;
+use crate::decoder::stateless::StatelessDecoder;
 use crate::decoder::BlockingMode;
 
 use crate::decoder::stateless::h265::StatelessH265DecoderBackend;
@@ -31,7 +32,7 @@ impl StatelessH265DecoderBackend for Backend {
         Ok(())
     }
 
-    fn handle_picture(
+    fn begin_picture(
         &mut self,
         _: &mut Self::Picture,
         _: &crate::codec::h265::picture::PictureData,
@@ -66,9 +67,9 @@ impl StatelessH265DecoderBackend for Backend {
         })
     }
 }
-impl Decoder<Handle, ()> {
+impl StatelessDecoder<H265, Backend> {
     // Creates a new instance of the decoder using the dummy backend.
-    pub fn new_dummy(blocking_mode: BlockingMode) -> anyhow::Result<Self> {
-        Self::new(Box::new(Backend::new()), blocking_mode)
+    pub fn new_dummy(blocking_mode: BlockingMode) -> Self {
+        Self::new(Backend::new(), blocking_mode)
     }
 }

--- a/src/decoder/stateless/h265/vaapi.rs
+++ b/src/decoder/stateless/h265/vaapi.rs
@@ -817,7 +817,10 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessDecoder<H265, VaapiBackend<B
         M: From<S>,
         S: From<M>,
     {
-        Self::new(VaapiBackend::<BackendData, M>::new(display), blocking_mode)
+        Self::new(
+            VaapiBackend::<BackendData, M>::new(display, false),
+            blocking_mode,
+        )
     }
 }
 

--- a/src/decoder/stateless/h265/vaapi.rs
+++ b/src/decoder/stateless/h265/vaapi.rs
@@ -825,6 +825,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessDecoder<H265, VaapiBackend<B
 mod tests {
     use libva::Display;
 
+    use crate::codec::h265::parser::Nalu;
     use crate::decoder::stateless::h265::H265;
     use crate::decoder::stateless::tests::test_decode_stream;
     use crate::decoder::stateless::tests::TestStream;
@@ -832,7 +833,7 @@ mod tests {
     use crate::decoder::BlockingMode;
     use crate::utils::simple_playback_loop;
     use crate::utils::simple_playback_loop_owned_surfaces;
-    use crate::utils::H265FrameIterator;
+    use crate::utils::NalIterator;
     use crate::DecodedFormat;
 
     /// Run `test` using the vaapi decoder, in both blocking and non-blocking modes.
@@ -848,7 +849,7 @@ mod tests {
             |d, s, f| {
                 simple_playback_loop(
                     d,
-                    H265FrameIterator::new(s),
+                    NalIterator::<Nalu<_>>::new(s),
                     f,
                     &mut simple_playback_loop_owned_surfaces,
                     output_format,

--- a/src/decoder/stateless/vp8/vaapi.rs
+++ b/src/decoder/stateless/vp8/vaapi.rs
@@ -294,7 +294,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessDecoder<Vp8, VaapiBackend<()
         M: From<S>,
         S: From<M>,
     {
-        Self::new(VaapiBackend::<(), M>::new(display), blocking_mode)
+        Self::new(VaapiBackend::<(), M>::new(display, false), blocking_mode)
     }
 }
 

--- a/src/decoder/stateless/vp9/vaapi.rs
+++ b/src/decoder/stateless/vp9/vaapi.rs
@@ -297,7 +297,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessDecoder<Vp9, VaapiBackend<()
         M: From<S>,
         S: From<M>,
     {
-        Self::new(VaapiBackend::<(), M>::new(display), blocking_mode)
+        Self::new(VaapiBackend::<(), M>::new(display, true), blocking_mode)
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,15 +9,13 @@
 
 use std::io::Cursor;
 use std::io::Seek;
+use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
 
 use bytes::Buf;
 
-use crate::codec::h264::nalu::Header;
-use crate::codec::h264::nalu_reader;
 use crate::codec::h264::parser::Nalu as H264Nalu;
 use crate::codec::h265::parser::Nalu as H265Nalu;
-use crate::codec::h265::parser::NaluType as H265NaluType;
 use crate::decoder::stateless::DecodeError;
 use crate::decoder::stateless::StatelessVideoDecoder;
 use crate::decoder::BlockingMode;
@@ -71,16 +69,16 @@ impl<'a> Iterator for IvfIterator<'a> {
     }
 }
 
-/// Iterator over groups of Nalus that can contain a whole frame.
-pub struct H264FrameIterator<'a>(Cursor<&'a [u8]>);
+/// Iterator NALUs in a bitstream.
+pub struct NalIterator<'a, Nalu>(Cursor<&'a [u8]>, PhantomData<Nalu>);
 
-impl<'a> H264FrameIterator<'a> {
+impl<'a, Nalu> NalIterator<'a, Nalu> {
     pub fn new(stream: &'a [u8]) -> Self {
-        Self(Cursor::new(stream))
+        Self(Cursor::new(stream), PhantomData)
     }
 }
 
-impl<'a> Iterator for H264FrameIterator<'a> {
+impl<'a> Iterator for NalIterator<'a, H264Nalu<&[u8]>> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -94,188 +92,17 @@ impl<'a> Iterator for H264FrameIterator<'a> {
     }
 }
 
-/// A H.265 Access Unit.
-#[derive(Debug, Default)]
-struct H265AccessUnit<T> {
-    pub nalus: Vec<H265Nalu<T>>,
-}
-
-#[derive(Debug, Default)]
-struct H265AccessUnitParser<T> {
-    picture_started: bool,
-    nalus: Vec<H265Nalu<T>>,
-}
-
-impl<T: AsRef<[u8]>> H265AccessUnitParser<T> {
-    /// Whether this is a slice type.
-    fn is_slice(nalu: &H265Nalu<T>) -> bool {
-        matches!(
-            nalu.header().nalu_type(),
-            H265NaluType::BlaWLp
-                | H265NaluType::BlaWRadl
-                | H265NaluType::BlaNLp
-                | H265NaluType::IdrWRadl
-                | H265NaluType::IdrNLp
-                | H265NaluType::TrailN
-                | H265NaluType::TrailR
-                | H265NaluType::TsaN
-                | H265NaluType::TsaR
-                | H265NaluType::StsaN
-                | H265NaluType::StsaR
-                | H265NaluType::RadlN
-                | H265NaluType::RadlR
-                | H265NaluType::RaslN
-                | H265NaluType::RaslR
-                | H265NaluType::CraNut
-        )
-    }
-
-    /// Whether this is a delimiter, which would automatically start a new AU.
-    fn is_delimiter(nalu: &H265Nalu<T>) -> bool {
-        matches!(
-            nalu.header().nalu_type(),
-            H265NaluType::AudNut | H265NaluType::EobNut | H265NaluType::EosNut
-        )
-    }
-
-    /// Whether this specifies a new AU, regardless of being one of the
-    /// delimiters as per `is_delimiter`. See this paragraph in F.7.4.2.4.4:
-    ///
-    /// The first of any of the following NAL units preceding the first VCL NAL
-    /// unit firstVclNalUnitInAu and succeeding the last VCL NAL unit preceding
-    /// firstVclNalUnitInAu, if any, specifies the start of a new access unit:
-    fn specifies_new_au(nalu: &H265Nalu<T>) -> bool {
-        matches!(
-            nalu.header().nalu_type(),
-            H265NaluType::PrefixSeiNut
-                | H265NaluType::VpsNut
-                | H265NaluType::SpsNut
-                | H265NaluType::PpsNut
-                | H265NaluType::RsvNvcl41
-                | H265NaluType::RsvNvcl42
-                | H265NaluType::RsvNvcl43
-                | H265NaluType::RsvNvcl44
-        )
-    }
-
-    /// Whether this is a slice of the next access unit.
-    fn is_slice_of_next_au(nalu: &H265Nalu<T>) -> bool {
-        if Self::is_slice(nalu) {
-            let data = nalu.as_ref();
-            let mut r = nalu_reader::NaluReader::new(&data[nalu.header().len()..]);
-
-            // first_slice_segment_in_pic
-            r.read_bit().expect("Malformed slice")
-        } else {
-            false
-        }
-    }
-
-    fn collect(&mut self, include_current_nalu: bool) -> Option<H265AccessUnit<T>> {
-        let len = if include_current_nalu {
-            self.nalus.len()
-        } else {
-            self.nalus.len() - 1
-        };
-
-        let au = H265AccessUnit {
-            nalus: self.nalus.drain(..len).collect::<Vec<_>>(),
-        };
-
-        log::debug!("Collecting access unit: (Nalu, Size): {:?}", {
-            au.nalus
-                .iter()
-                .map(|nalu| (nalu.header().nalu_type(), nalu.size()))
-                .collect::<Vec<_>>()
-        });
-
-        let no_slices_left = !self.nalus.iter().any(|nalu| Self::is_slice(nalu));
-
-        if no_slices_left {
-            // Wait for a new slice.
-            self.picture_started = false;
-        }
-
-        Some(au)
-    }
-
-    /// Accumulates NALUs into Access Units based on gsth265parser's heuristics
-    /// and on "F.7.4.2.4.4 Order of NAL units and coded pictures and
-    /// association to access units" to accumulate NAL units.
-    pub fn accumulate(&mut self, nalu: H265Nalu<T>) -> Option<H265AccessUnit<T>> {
-        // Accumulate until we see a slice.
-        self.nalus.push(nalu);
-        let nalu = self.nalus.last().unwrap();
-
-        if Self::is_delimiter(nalu) && self.picture_started {
-            return self.collect(true);
-        }
-
-        if !self.picture_started {
-            self.picture_started = Self::is_slice(nalu);
-            return None;
-        }
-
-        if Self::specifies_new_au(nalu) {
-            return self.collect(false);
-        }
-        if Self::is_slice_of_next_au(nalu) {
-            return self.collect(false);
-        }
-
-        None
-    }
-}
-
-/// Iterator over groups of Nalus that can contain a whole frame.
-pub struct H265FrameIterator<'a> {
-    cursor: Cursor<&'a [u8]>,
-    aud_parser: H265AccessUnitParser<&'a [u8]>,
-}
-
-impl<'a> H265FrameIterator<'a> {
-    pub fn new(stream: &'a [u8]) -> Self {
-        Self {
-            cursor: Cursor::new(stream),
-            aud_parser: Default::default(),
-        }
-    }
-}
-
-impl<'a> Iterator for H265FrameIterator<'a> {
+impl<'a> Iterator for NalIterator<'a, H265Nalu<&[u8]>> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
-        while let Ok(nalu) = H265Nalu::next(&mut self.cursor) {
-            if let Some(access_unit) = self.aud_parser.accumulate(nalu) {
-                let start_nalu = access_unit.nalus.first().unwrap();
-                let end_nalu = access_unit.nalus.last().unwrap();
-
-                let start_offset = start_nalu.sc_offset();
-                let end_offset = end_nalu.offset() + end_nalu.size();
-
-                let data = &self.cursor.get_ref()[start_offset..end_offset];
-
-                return Some(data);
-            }
-        }
-
-        // Process any left over NALUs, even if we could not fit them into an AU using the
-        // heuristic.
-        if !self.aud_parser.nalus.is_empty() {
-            let nalus = self.aud_parser.nalus.drain(..).collect::<Vec<_>>();
-            let start_nalu = nalus.first().unwrap();
-            let end_nalu = nalus.last().unwrap();
-
-            let start_offset = start_nalu.sc_offset();
-            let end_offset = end_nalu.offset() + end_nalu.size();
-
-            let data = &self.cursor.get_ref()[start_offset..end_offset];
-
-            Some(data)
-        } else {
-            None
-        }
+        H265Nalu::next(&mut self.0)
+            .map(|n| {
+                let start = n.sc_offset();
+                let end = n.offset() + n.size();
+                &n.data()[start..end]
+            })
+            .ok()
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,7 @@ use bytes::Buf;
 
 use crate::codec::h264::nalu::Header;
 use crate::codec::h264::nalu_reader;
-use crate::codec::h264::parser::Nalu;
+use crate::codec::h264::parser::Nalu as H264Nalu;
 use crate::codec::h265::parser::Nalu as H265Nalu;
 use crate::codec::h265::parser::NaluType as H265NaluType;
 use crate::decoder::stateless::DecodeError;
@@ -84,7 +84,7 @@ impl<'a> Iterator for H264FrameIterator<'a> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
-        Nalu::next(&mut self.0)
+        H264Nalu::next(&mut self.0)
             .map(|n| {
                 let start = n.sc_offset();
                 let end = n.offset() + n.size();


### PR DESCRIPTION
This "completes" the H.265 for now. Current scores for JCT-VC-HEVC_V1 on my machine are 138 and 136 on Intel and AMD, respectively, out of 147.

Most improvements can now be made as small commits without changing much of the structure itself.

Currently WIP:

a) More support for other profiles and bit depths, including things like SCC, range extension and so on.

b) A refactor of {H264|H265}FrameIterator (as they're very similar)

~~c) Optionally changing NALU ordering for ccdec. This will enable us to process some streams wherein the PPS is sent before the SPS. While client code is expected to submit a stream wherein the SPS comes first, it is still advantageous for us to try to process these 'malformed' streams with ccdec as it allows us to catch more bugs with fluster.~~

d) a change in our crop rectangle/display resolution code. JCT-VC-HEVC_V1 includes a CONFWIN test in which we can see that our implementation does the wrong thing, i.e. it crops the image at the wrong offset. This means that the picture decodes OK, but the result is panned in a wrong way.