### PR TITLE
workflows: Add LAVA tests workflow

### DIFF
--- a/.github/workflows/lava.yml
+++ b/.github/workflows/lava.yml
@@ -1,0 +1,41 @@
+name: Run LAVA tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  submit-job:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+    strategy:
+      matrix:
+        arch: 
+          - intel
+          - amd
+
+    steps:
+    - name: Install lavacli
+      run: sudo apt-get install lavacli
+    - name: Add lava identity
+      run: lavacli identities add --token ${{ secrets.LAVA_TOKEN }} --uri ${{ vars.LAVA_URL }}/RPC2 --username ${{ vars.LAVA_USERNAME }} ci
+    - uses: actions/checkout@v3
+    - name: Create job description
+      run: ./ci/lava_job_generate.py --template ci/template.yaml --arch ${{ matrix.arch }} --ccdec-build-id "${{ github.run_id }}" --test-repo "${{ github.server_url }}/${{ github.repository }}" --test-branch "${GITHUB_REF_NAME}" --config-file ci/config.yaml --token ${{ secrets.GH_BEARER }} --repo ${GITHUB_REPOSITORY} | tee job.yaml
+    - name: Submit job
+      run: lavacli -i ci jobs submit job.yaml | tee lava-jobid.txt
+    - name: Log job
+      run: lavacli -i ci jobs logs $(cat lava-jobid.txt)
+    - name: Retrieve test results
+      # lavacli doesn't support retrieving results in the JUnit format. Use the REST API
+      run: "curl -H \"Authorization: Token ${{ secrets.LAVA_TOKEN }}\" ${{ vars.LAVA_URL }}/api/v0.2/jobs/$(cat lava-jobid.txt)/junit/ > results-junit.xml"
+    - name: Test results
+      uses: dorny/test-reporter@v1.7.0
+      with:
+        name: Cros-codecs tests results for ${{ matrix.arch }}
+        path: '*.xml'
+        reporter: java-junit
+        fail-on-error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: awalsh128/cache-apt-pkgs-action@latest
@@ -28,3 +28,11 @@ jobs:
       run: cargo test --verbose
     - name: Format
       run: cargo fmt --check --all
+    - name: Build release
+      run: cargo build --all-features --examples --release
+    - name: Upload built binary artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: ccdec-bin
+        path: target/release/examples/ccdec
+

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -1,0 +1,132 @@
+intel:
+  device_type: acer-chromebox-cxi4-puff
+  codecs:
+    - vp8:
+        test-suites:
+          - vp8-test-vectors:
+              skip-vectors: []
+    - vp9:
+        test-suites:
+          - vp9-test-vectors:
+              skip-vectors:
+                - vp90-2-22-svc_1280x720_3.ivf
+                - vp91-2-04-yuv422.webm
+                - vp91-2-04-yuv444.webm
+    - h.264:
+        test-suites:
+          - JVT-AVC_V1:
+              skip-vectors:
+                - CVFC1_Sony_C
+                - FM1_BT_B
+                - FM1_FT_E
+                - FM2_SVA_C
+                - MR5_TANDBERG_C
+                - MR8_BT_B
+                - MR9_BT_B
+                - SP1_BT_A
+                - sp2_bt_b
+    - h.265:
+        test-suites:
+          - JCT-VC-HEVC_V1:
+              skip-vectors:
+                - CONFWIN_A_Sony_1
+                - PICSIZE_A_Bossen_1
+                - PICSIZE_B_Bossen_1
+                - RAP_B_Bossen_2
+                - RPS_C_ericsson_5
+                - RPS_E_qualcomm_5
+                - TSUNEQBD_A_MAIN10_Technicolor_2
+
+amd:
+  device_type: hp-11A-G6-EE-grunt
+  codecs:
+    - h.264:
+        test-suites:
+          - JVT-AVC_V1:
+              skip-vectors:
+                - CVFC1_Sony_C
+                - FM1_BT_B
+                - FM1_FT_E
+                - FM2_SVA_C
+                - MR3_TANDBERG_B
+                - MR4_TANDBERG_C
+                - MR5_TANDBERG_C
+                - SP1_BT_A
+                - sp2_bt_b
+    - h.265:
+        test-suites:
+          - JCT-VC-HEVC_V1:
+              skip-vectors:
+                - AMP_D_Hisilicon_3
+                - AMP_E_Hisilicon_3
+                - CAINIT_A_SHARP_4
+                - CAINIT_B_SHARP_4
+                - CIP_A_Panasonic_3
+                - CIP_C_Panasonic_2
+                - CONFWIN_A_Sony_1
+                - DBLK_A_MAIN10_VIXS_4
+                - DBLK_D_VIXS_2
+                - DBLK_E_VIXS_2
+                - DBLK_F_VIXS_2
+                - DBLK_G_VIXS_2
+                - DSLICE_A_HHI_5
+                - DSLICE_B_HHI_5
+                - DSLICE_C_HHI_5
+                - ENTP_B_Qualcomm_1
+                - LTRPSPS_A_Qualcomm_1
+                - MAXBINS_C_TI_5
+                - MERGE_A_TI_3
+                - MERGE_B_TI_3
+                - MERGE_C_TI_3
+                - MERGE_D_TI_3
+                - MERGE_E_TI_3
+                - MVDL1ZERO_A_docomo_4
+                - NoOutPrior_A_Qualcomm_1
+                - NoOutPrior_B_Qualcomm_1
+                - NUT_A_ericsson_5
+                - OPFLAG_A_Qualcomm_1
+                - OPFLAG_C_Qualcomm_1
+                - PICSIZE_A_Bossen_1
+                - PICSIZE_B_Bossen_1
+                - PICSIZE_C_Bossen_1
+                - PICSIZE_D_Bossen_1
+                - PMERGE_A_TI_3
+                - PMERGE_B_TI_3
+                - PMERGE_C_TI_3
+                - PMERGE_D_TI_3
+                - PMERGE_E_TI_3
+                - RAP_A_docomo_6
+                - RAP_B_Bossen_2
+                - RPLM_A_qualcomm_4
+                - RPLM_B_qualcomm_4
+                - RPS_A_docomo_5
+                - RPS_C_ericsson_5
+                - RPS_E_qualcomm_5
+                - RPS_F_docomo_2
+                - SAO_A_MediaTek_4
+                - SAO_B_MediaTek_5
+                - SAO_E_Canon_4
+                - SAO_F_Canon_3
+                - SAO_G_Canon_3
+                - SAODBLK_A_MainConcept_4
+                - SAODBLK_B_MainConcept_4
+                - SDH_A_Orange_4
+                - SLICES_A_Rovi_3
+                - SLIST_B_Sony_9
+                - SLIST_D_Sony_9
+                - TSUNEQBD_A_MAIN10_Technicolor_2
+                - WP_A_MAIN10_Toshiba_3
+                - WP_B_Toshiba_3
+                - WP_MAIN10_B_Toshiba_3
+                - WPP_A_ericsson_MAIN10_2
+                - WPP_A_ericsson_MAIN_2
+                - WPP_B_ericsson_MAIN10_2
+                - WPP_B_ericsson_MAIN_2
+                - WPP_C_ericsson_MAIN10_2
+                - WPP_C_ericsson_MAIN_2
+                - WPP_D_ericsson_MAIN10_2
+                - WPP_D_ericsson_MAIN_2
+                - WPP_E_ericsson_MAIN10_2
+                - WPP_E_ericsson_MAIN_2
+                - WPP_F_ericsson_MAIN10_2
+                - WPP_F_ericsson_MAIN_2

--- a/ci/lava_job_generate.py
+++ b/ci/lava_job_generate.py
@@ -1,0 +1,38 @@
+#!/bin/env python3
+
+import argparse
+import jinja2
+import os
+import yaml
+
+def get_device_type(arch, config_file):
+    with open(config_file, "r") as stream:
+        try:
+            config = yaml.safe_load(stream)
+            return config[arch]['device_type']
+        except yaml.YAMLError as exc:
+            print(exc)
+
+def main():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument('--template', help='Input template file', required=True)
+    argparser.add_argument('--test-branch', help='The branch being tested', default='main')
+    argparser.add_argument('--test-repo', help='The repository being tested', required=True)
+    argparser.add_argument('--arch', choices=['amd', 'intel'], help='Architecture', required=True)
+    argparser.add_argument('--ccdec-build-id', help='ccdec build id', required=True)
+    argparser.add_argument('--token', help='Github read token', required=True)
+    argparser.add_argument('--repo', help='Github repository', required=True)
+    argparser.add_argument('--config-file', help='Configuration file', required=True)
+    args = argparser.parse_args()
+
+    env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.dirname(args.template)),
+                             undefined=jinja2.StrictUndefined)
+
+    template = env.get_template(os.path.basename(args.template))
+
+    print(template.render(ccdec_build_id=args.ccdec_build_id, arch=args.arch, device_type=get_device_type(args.arch, args.config_file), test_branch=args.test_branch, repo_url=args.test_repo, token=args.token, repo=args.repo))
+
+
+if __name__ == '__main__':
+    main()
+

--- a/ci/template.yaml
+++ b/ci/template.yaml
@@ -1,0 +1,72 @@
+context:
+  extra_kernel_args: console_msg_format=syslog earlycon
+device_type: {{ device_type }}
+job_name: Test cros-codecs on {{ arch }}
+
+priority: medium
+timeouts:
+  action:
+    minutes: 120
+  actions:
+    power-off:
+      seconds: 30
+  job:
+    minutes: 120
+  queue:
+    days: 2
+visibility: public
+
+actions:
+- deploy:
+    namespace: cros-codecs
+    kernel:
+      url: https://storage.chromeos.kernelci.org/images/kernel/cros---chromeos-6.1-x86_64-chromiumos-x86_64.flavour.config+x86-chromebook/clang-14/kernel/bzImage
+    modules:
+      compression: xz
+      url: https://storage.chromeos.kernelci.org/images/kernel/cros---chromeos-6.1-x86_64-chromiumos-x86_64.flavour.config+x86-chromebook/clang-14/modules.tar.xz
+    nfsrootfs:
+      compression: xz
+      url: https://storage.kernelci.org/images/rootfs/debian/bullseye-gst-fluster/20231117.0/amd64/full.rootfs.tar.xz
+    os: oe
+    ramdisk:
+      compression: gz
+      url: https://storage.kernelci.org/images/rootfs/debian/bullseye-gst-fluster/20231117.0/amd64/initrd.cpio.gz
+    timeout:
+      minutes: 15
+    to: tftp
+- boot:
+    commands: nfs
+    method: depthcharge
+    namespace: cros-codecs
+    prompts:
+    - '/ #'
+    timeout:
+      minutes: 5
+- test:
+    definitions:
+       - repository: {{ repo_url }}
+         branch: '{{ test_branch }}'
+         history: False
+         from: git
+         name: run_fluster
+         path: ci/test-cases/cros-codecs.yaml
+         params:
+           CCDEC_BUILD_ID: {{ ccdec_build_id }}
+           ARCH: {{ arch }}
+           GITHUB_TOKEN: {{ token }}
+           GITHUB_REPO: {{ repo }}
+       - repository: {{ repo_url }}
+         branch: '{{ test_branch }}'
+         history: False
+         from: git
+         name: run_fluster_single
+         path: ci/test-cases/cros-codecs-single.yaml
+         params:
+           CCDEC_BUILD_ID: {{ ccdec_build_id }}
+           ARCH: {{ arch }}
+           GITHUB_TOKEN: {{ token }}
+           GITHUB_REPO: {{ repo }}
+    namespace: cros-codecs
+    timeout:
+      minutes: 120
+

--- a/ci/test-cases/cros-codecs-single.yaml
+++ b/ci/test-cases/cros-codecs-single.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: cros-codecs-fluster-single
+  description: "Test cros-codecs in a single thread"
+
+run:
+  steps:
+    - python3 ci/test-cases/run_tests.py --config-file ci/config.yaml --arch ${ARCH} --ccdec-build-id ${CCDEC_BUILD_ID} --token ${GITHUB_TOKEN} --repo ${GITHUB_REPO} --single

--- a/ci/test-cases/cros-codecs.yaml
+++ b/ci/test-cases/cros-codecs.yaml
@@ -1,0 +1,7 @@
+metadata:
+  name: cros-codecs-fluster
+  description: "Test cros-codecs"
+
+run:
+  steps:
+    - python3 ci/test-cases/run_tests.py --config-file ci/config.yaml --arch ${ARCH} --ccdec-build-id ${CCDEC_BUILD_ID} --token ${GITHUB_TOKEN} --repo ${GITHUB_REPO}

--- a/ci/test-cases/run_tests.py
+++ b/ci/test-cases/run_tests.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import stat
+import subprocess
+import yaml
+import requests
+import time
+
+URL_RUNS="https://api.github.com/repos/{repo}/actions/runs?head-sha={head_sha}&head-branch={head_branch}&per_page=2"
+URL_RUN="https://api.github.com/repos/{repo}/actions/runs/{run_id}"
+
+def run_fluster(codec, test_suite, skips, single_thread):
+    print(f"  {codec} -> {test_suite} (skip: {skips})")
+    cmd = ['python3', '/usr/bin/fluster_parser.py', '-ts', test_suite, '-d', f"ccdec-{codec}", '-t' '300']
+
+    if single_thread:
+        cmd.extend(['-j', '1'])
+    if skips:
+        for index, skip in enumerate(skips):
+            cmd.extend(['-sv', skip] if not index else [skip])
+
+    print(cmd)
+    subprocess.run(cmd, check=False)
+
+def retrieve_ccdec_github(sha, branch, repo, token):
+    if os.path.exists("/opt/cros-codecs/ccdec"):
+        os.environ['PATH'] = os.environ['PATH'] + ":/opt/cros-codecs"
+        return True
+
+    runs = requests.get(URL_RUNS.format(head_sha=sha, head_branch=branch, repo=repo), headers={"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28", "Authorization": f"Bearer {token}"}).json()
+
+    found = False
+
+    for run in runs['workflow_runs']:
+        if run['name'] != 'Health check':
+            continue
+
+        artifacts = requests.get(run['artifacts_url'], headers={"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28", "Authorization": f"Bearer {token}"}).json()
+
+        if artifacts['total_count'] == 0:
+            break
+
+        for artifact in artifacts['artifacts']:
+            if artifact['name'] != 'ccdec-bin':
+                continue
+
+            r = requests.get(artifact['archive_download_url'], headers={"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28", "Authorization": f"Bearer {token}"}, stream=True)
+
+            if not os.path.exists("/opt/cros-codecs"):
+                os.mkdir("/opt/cros-codecs")
+
+            with open("/opt/cros-codecs/ccdec.zip", 'wb') as fd:
+                for chunk in r.iter_content(chunk_size=128):
+                    fd.write(chunk)
+
+            subprocess.run(['unzip', '/opt/cros-codecs/ccdec.zip', '-d', '/opt/cros-codecs/'])
+            os.chmod("/opt/cros-codecs/ccdec", mode=(stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO))
+            os.environ['PATH'] = os.environ['PATH'] + ":/opt/cros-codecs"
+
+            found = True
+
+            break
+
+        break
+
+    return found
+
+def retrieve_ccdec(run_id, repo, token):
+    # Retrieve built sha and branch
+    run = requests.get(URL_RUN.format(run_id=run_id, repo=repo), headers={"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28", "Authorization": f"Bearer {token}"}).json()
+    sha = run['head_sha']
+    branch = run['head_branch']
+
+    # Retrieve the artifact
+    for i in range(30):
+        try:
+            if retrieve_ccdec_github(sha, branch, repo, token):
+                break
+            time.sleep(10)
+        except Exception as e:
+            print(e)
+
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--arch', choices=['amd', 'intel'], help='Architecture', required=True)
+argparser.add_argument('--config-file', help='Configuration file', required=True)
+argparser.add_argument('--ccdec-build-id', help='ccded binary build id', required=True)
+argparser.add_argument('--token', help='Github read token', required=True)
+argparser.add_argument('--repo', help='Github git repository', required=True)
+argparser.add_argument('--single', help='Run in a single thread', action='store_true')
+args = argparser.parse_args()
+
+retrieve_ccdec(args.ccdec_build_id, args.repo, args.token)
+
+with open(args.config_file, "r") as stream:
+    try:
+        config = yaml.safe_load(stream)
+        for arch, arch_info in config.items():
+            if arch != args.arch:
+                continue
+            device_type=arch_info['device_type']
+            for c in arch_info['codecs']:
+                for codec, test_suites in c.items():
+                    for ts in test_suites['test-suites']:
+                        for test_suite in ts:
+                            skips=ts[test_suite]["skip-vectors"]
+                            run_fluster(codec, test_suite, skips, args.single)
+            break
+    except yaml.YAMLError as exc:
+        print(exc)


### PR DESCRIPTION
# cros-codecs CI workflow:
 - cros-codecs (on each cros-codecs push):
   - Build ccdec
   - Save artifacts
   - Run lavacli submit -> the template runs the rootfs at https://storage.kernelci.org/images/rootfs/debian/bullseye-gst-fluster/20231117.0/amd64/
   - wait for lava results
   - Show tests results (See example [here](https://github.com/cazou/cros-codecs/actions/runs/5978557533))
 - LAVA (on each cros-codecs push):
   - get and boot latest NFS image generated by kernelCI
   - get the test definition (in the ci dir)
   - Download ccdec artifact from github
   - run the tests

The `ci/config.yaml`  contains the test configurations. For each architecture (amd/intel), it specifies:
 - The lava device type to use
 - The supported codecs for the architecture (`vp8`, `h.264`, ...)
 - The test suites to be run for each codec (currently one per codec)
 - The test vectors to be skipped in each test suite

The github action workflow uses `ci/config.yaml` to get the lava `device_type`  to run the test on.
The test on lava is run from `ci/test-cases/run_tests.py` and uses `ci/config.yaml` to generate the fluster command to run.

# About the lava test job
 - Only NFS images are used. The hardware is not being tested, only cros-codecs is, no need to flash anything on the hardware.
