### PR TITLE
codec/h264: remove generic argument from NaluReader

### DIFF
--- a/examples/ccdec.rs
+++ b/examples/ccdec.rs
@@ -338,7 +338,7 @@ fn main() {
     let display = libva::Display::open().expect("failed to open libva display");
     let (mut decoder, frame_iter) = match args.input_format {
         EncodedFormat::H264 => {
-            let frame_iter = Box::new(NalIterator::<H264Nalu<_>>::new(&input).map(Cow::Borrowed))
+            let frame_iter = Box::new(NalIterator::<H264Nalu>::new(&input).map(Cow::Borrowed))
                 as Box<dyn Iterator<Item = Cow<[u8]>>>;
 
             let decoder = Box::new(StatelessDecoder::<H264, _>::new_vaapi(
@@ -369,7 +369,7 @@ fn main() {
             (decoder, frame_iter)
         }
         EncodedFormat::H265 => {
-            let frame_iter = Box::new(NalIterator::<H265Nalu<_>>::new(&input).map(Cow::Borrowed))
+            let frame_iter = Box::new(NalIterator::<H265Nalu>::new(&input).map(Cow::Borrowed))
                 as Box<dyn Iterator<Item = Cow<[u8]>>>;
 
             let decoder = Box::new(StatelessDecoder::<H265, _>::new_vaapi(

--- a/src/codec/h264/nalu_reader.rs
+++ b/src/codec/h264/nalu_reader.rs
@@ -9,9 +9,9 @@ use bytes::Buf;
 
 /// A bit reader for h264 bitstreams. It properly handles emulation-prevention
 /// bytes and stop bits.
-pub struct NaluReader<T> {
+pub(crate) struct NaluReader<'a> {
     /// A reference into the next unread byte in the stream.
-    data: Cursor<T>,
+    data: Cursor<&'a [u8]>,
     /// Contents of the current byte. First unread bit starting at position 8 -
     /// num_remaining_bits_in_curr_bytes.
     curr_byte: u32,
@@ -23,8 +23,8 @@ pub struct NaluReader<T> {
     num_epb: usize,
 }
 
-impl<T: AsRef<[u8]>> NaluReader<T> {
-    pub fn new(data: T) -> Self {
+impl<'a> NaluReader<'a> {
+    pub fn new(data: &'a [u8]) -> Self {
         Self {
             data: Cursor::new(data),
             curr_byte: Default::default(),

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -1534,8 +1534,8 @@ impl Parser {
         }
     }
 
-    fn parse_scaling_list<T: AsRef<[u8]>, U: AsMut<[u8]>>(
-        r: &mut NaluReader<T>,
+    fn parse_scaling_list<U: AsMut<[u8]>>(
+        r: &mut NaluReader,
         scaling_list: &mut U,
         use_default: &mut bool,
     ) -> anyhow::Result<()> {
@@ -1565,10 +1565,7 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_sps_scaling_lists<T: AsRef<[u8]>>(
-        r: &mut NaluReader<T>,
-        sps: &mut Sps,
-    ) -> anyhow::Result<()> {
+    fn parse_sps_scaling_lists(r: &mut NaluReader, sps: &mut Sps) -> anyhow::Result<()> {
         let scaling_lists4x4 = &mut sps.scaling_lists_4x4;
         let scaling_lisst8x8 = &mut sps.scaling_lists_8x8;
 
@@ -1616,11 +1613,7 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_pps_scaling_lists<T: AsRef<[u8]>>(
-        r: &mut NaluReader<T>,
-        pps: &mut Pps,
-        sps: &Sps,
-    ) -> anyhow::Result<()> {
+    fn parse_pps_scaling_lists(r: &mut NaluReader, pps: &mut Pps, sps: &Sps) -> anyhow::Result<()> {
         let scaling_lists4x4 = &mut pps.scaling_lists_4x4;
         let scaling_lists8x8 = &mut pps.scaling_lists_8x8;
 
@@ -1689,7 +1682,7 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_hrd<T: AsRef<[u8]>>(r: &mut NaluReader<T>, hrd: &mut HrdParams) -> anyhow::Result<()> {
+    fn parse_hrd(r: &mut NaluReader, hrd: &mut HrdParams) -> anyhow::Result<()> {
         hrd.cpb_cnt_minus1 = r.read_ue_max(31)?;
         hrd.bit_rate_scale = r.read_bits(4)?;
         hrd.cpb_size_scale = r.read_bits(4)?;
@@ -1707,7 +1700,7 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_vui<T: AsRef<[u8]>>(r: &mut NaluReader<T>, sps: &mut Sps) -> anyhow::Result<()> {
+    fn parse_vui(r: &mut NaluReader, sps: &mut Sps) -> anyhow::Result<()> {
         let vui = &mut sps.vui_parameters;
 
         vui.aspect_ratio_info_present_flag = r.read_bit()?;
@@ -2064,8 +2057,8 @@ impl Parser {
         Ok(self.get_pps(key).unwrap())
     }
 
-    fn parse_ref_pic_list_modification<T: AsRef<[u8]>>(
-        r: &mut NaluReader<T>,
+    fn parse_ref_pic_list_modification(
+        r: &mut NaluReader,
         num_ref_idx_active_minus1: u8,
         ref_list_mods: &mut Vec<RefPicListModification>,
     ) -> anyhow::Result<()> {
@@ -2102,8 +2095,8 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_ref_pic_list_modifications<T: AsRef<[u8]>>(
-        r: &mut NaluReader<T>,
+    fn parse_ref_pic_list_modifications(
+        r: &mut NaluReader,
         header: &mut SliceHeader,
     ) -> anyhow::Result<()> {
         if !header.slice_type.is_i() && !header.slice_type.is_si() {
@@ -2131,8 +2124,8 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_pred_weight_table<T: AsRef<[u8]>>(
-        r: &mut NaluReader<T>,
+    fn parse_pred_weight_table(
+        r: &mut NaluReader,
         sps: &Sps,
         header: &mut SliceHeader,
     ) -> anyhow::Result<()> {
@@ -2222,8 +2215,8 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_dec_ref_pic_marking<T: AsRef<[u8]>, U: AsRef<[u8]>>(
-        r: &mut NaluReader<T>,
+    fn parse_dec_ref_pic_marking<U: AsRef<[u8]>>(
+        r: &mut NaluReader,
         nalu: &Nalu<U>,
         header: &mut SliceHeader,
     ) -> anyhow::Result<()> {

--- a/src/codec/h264/picture.rs
+++ b/src/codec/h264/picture.rs
@@ -114,7 +114,7 @@ impl PictureData {
         }
     }
 
-    pub fn new_from_slice(slice: &Slice<&[u8]>, sps: &Sps, timestamp: u64) -> Self {
+    pub fn new_from_slice(slice: &Slice, sps: &Sps, timestamp: u64) -> Self {
         let hdr = slice.header();
         let nalu_hdr = slice.nalu().header();
 

--- a/src/codec/h265/parser.rs
+++ b/src/codec/h265/parser.rs
@@ -3808,9 +3808,9 @@ impl Parser {
         Ok(self.get_vps(key).unwrap())
     }
 
-    fn parse_profile_tier_level<T: AsRef<[u8]>>(
+    fn parse_profile_tier_level(
         ptl: &mut ProfileTierLevel,
-        r: &mut NaluReader<T>,
+        r: &mut NaluReader,
         profile_present_flag: bool,
         sps_max_sub_layers_minus_1: u8,
     ) -> anyhow::Result<()> {
@@ -4053,10 +4053,7 @@ impl Parser {
         }
     }
 
-    fn parse_scaling_list_data<T: AsRef<[u8]>>(
-        sl: &mut ScalingLists,
-        r: &mut NaluReader<T>,
-    ) -> anyhow::Result<()> {
+    fn parse_scaling_list_data(sl: &mut ScalingLists, r: &mut NaluReader) -> anyhow::Result<()> {
         // 7.4.5
         for size_id in 0..4 {
             let mut matrix_id = 0;
@@ -4144,10 +4141,10 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_short_term_ref_pic_set<T: AsRef<[u8]>>(
+    fn parse_short_term_ref_pic_set(
         sps: &Sps,
         st: &mut ShortTermRefPicSet,
-        r: &mut NaluReader<T>,
+        r: &mut NaluReader,
         st_rps_idx: u8,
     ) -> anyhow::Result<()> {
         if st_rps_idx != 0 {
@@ -4305,11 +4302,11 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_sublayer_hrd_parameters<T: AsRef<[u8]>>(
+    fn parse_sublayer_hrd_parameters(
         h: &mut SublayerHrdParameters,
         cpb_cnt: u32,
         sub_pic_hrd_params_present_flag: bool,
-        r: &mut NaluReader<T>,
+        r: &mut NaluReader,
     ) -> anyhow::Result<()> {
         for i in 0..cpb_cnt as usize {
             h.bit_rate_value_minus1[i] = r.read_ue_max((2u64.pow(32) - 2) as u32)?;
@@ -4325,11 +4322,11 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_hrd_parameters<T: AsRef<[u8]>>(
+    fn parse_hrd_parameters(
         common_inf_present_flag: bool,
         max_num_sublayers_minus1: u8,
         hrd: &mut HrdParams,
-        r: &mut NaluReader<T>,
+        r: &mut NaluReader,
     ) -> anyhow::Result<()> {
         if common_inf_present_flag {
             hrd.nal_hrd_parameters_present_flag = r.read_bit()?;
@@ -4390,10 +4387,7 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_vui_parameters<T: AsRef<[u8]>>(
-        sps: &mut Sps,
-        r: &mut NaluReader<T>,
-    ) -> anyhow::Result<()> {
+    fn parse_vui_parameters(sps: &mut Sps, r: &mut NaluReader) -> anyhow::Result<()> {
         let vui = &mut sps.vui_parameters;
 
         vui.aspect_ratio_info_present_flag = r.read_bit()?;
@@ -4488,10 +4482,7 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_sps_scc_extension<T: AsRef<[u8]>>(
-        sps: &mut Sps,
-        r: &mut NaluReader<T>,
-    ) -> anyhow::Result<()> {
+    fn parse_sps_scc_extension(sps: &mut Sps, r: &mut NaluReader) -> anyhow::Result<()> {
         let scc = &mut sps.scc_extension;
 
         scc.curr_pic_ref_enabled_flag = r.read_bit()?;
@@ -4527,10 +4518,7 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_sps_range_extension<T: AsRef<[u8]>>(
-        sps: &mut Sps,
-        r: &mut NaluReader<T>,
-    ) -> anyhow::Result<()> {
+    fn parse_sps_range_extension(sps: &mut Sps, r: &mut NaluReader) -> anyhow::Result<()> {
         let ext = &mut sps.range_extension;
 
         ext.transform_skip_rotation_enabled_flag = r.read_bit()?;
@@ -4765,11 +4753,7 @@ impl Parser {
         Ok(self.get_sps(key).unwrap())
     }
 
-    fn parse_pps_scc_extension<T: AsRef<[u8]>>(
-        pps: &mut Pps,
-        sps: &Sps,
-        r: &mut NaluReader<T>,
-    ) -> anyhow::Result<()> {
+    fn parse_pps_scc_extension(pps: &mut Pps, sps: &Sps, r: &mut NaluReader) -> anyhow::Result<()> {
         let scc = &mut pps.scc_extension;
         scc.curr_pic_ref_enabled_flag = r.read_bit()?;
         scc.residual_adaptive_colour_transform_enabled_flag = r.read_bit()?;
@@ -4815,10 +4799,10 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_pps_range_extension<T: AsRef<[u8]>>(
+    fn parse_pps_range_extension(
         pps: &mut Pps,
         sps: &Sps,
-        r: &mut NaluReader<T>,
+        r: &mut NaluReader,
     ) -> anyhow::Result<()> {
         let rext = &mut pps.range_extension;
 
@@ -5036,9 +5020,9 @@ impl Parser {
         Ok(self.get_pps(key).unwrap())
     }
 
-    pub fn parse_pred_weight_table<T: AsRef<[u8]>>(
+    fn parse_pred_weight_table(
         hdr: &mut SliceHeader,
-        r: &mut NaluReader<T>,
+        r: &mut NaluReader,
         sps: &Sps,
     ) -> anyhow::Result<()> {
         let pwt = &mut hdr.pred_weight_table;
@@ -5110,9 +5094,9 @@ impl Parser {
         Ok(())
     }
 
-    fn parse_ref_pic_lists_modification<T: AsRef<[u8]>>(
+    fn parse_ref_pic_lists_modification(
         hdr: &mut SliceHeader,
-        r: &mut NaluReader<T>,
+        r: &mut NaluReader,
     ) -> anyhow::Result<()> {
         let rplm = &mut hdr.ref_pic_list_modification;
 

--- a/src/codec/h265/parser.rs
+++ b/src/codec/h265/parser.rs
@@ -220,7 +220,7 @@ impl Header for NaluHeader {
     }
 }
 
-pub type Nalu<T> = nalu::Nalu<T, NaluHeader>;
+pub type Nalu<'a> = nalu::Nalu<'a, NaluHeader>;
 
 /// H265 levels as defined by table A.8.
 /// `general_level_idc` and `sub_layer_level_idc[ OpTid ]` shall be set equal to a
@@ -2970,21 +2970,21 @@ impl Default for SliceHeader {
 
 /// A H265 slice. An integer number of macroblocks or macroblock pairs ordered
 /// consecutively in the raster scan within a particular slice group
-pub struct Slice<T> {
+pub struct Slice<'a> {
     /// The slice header.
     header: SliceHeader,
     /// The NAL unit backing this slice.
-    nalu: Nalu<T>,
+    nalu: Nalu<'a>,
 }
 
-impl<T> Slice<T> {
+impl<'a> Slice<'a> {
     /// Get a reference to the slice's header.
     pub fn header(&self) -> &SliceHeader {
         &self.header
     }
 
     /// Get a reference to the slice's nalu.
-    pub fn nalu(&self) -> &Nalu<T> {
+    pub fn nalu(&self) -> &Nalu {
         &self.nalu
     }
 
@@ -3666,7 +3666,7 @@ pub struct Parser {
 
 impl Parser {
     /// Parse a VPS NALU.
-    pub fn parse_vps<T: AsRef<[u8]>>(&mut self, nalu: &Nalu<T>) -> anyhow::Result<&Vps> {
+    pub fn parse_vps(&mut self, nalu: &Nalu) -> anyhow::Result<&Vps> {
         if !matches!(nalu.header().type_, NaluType::VpsNut) {
             return Err(anyhow!(
                 "Invalid NALU type, expected {:?}, got {:?}",
@@ -4535,7 +4535,7 @@ impl Parser {
     }
 
     /// Parse a SPS NALU.
-    pub fn parse_sps<T: AsRef<[u8]>>(&mut self, nalu: &Nalu<T>) -> anyhow::Result<&Sps> {
+    pub fn parse_sps(&mut self, nalu: &Nalu) -> anyhow::Result<&Sps> {
         if !matches!(nalu.header().type_, NaluType::SpsNut) {
             return Err(anyhow!(
                 "Invalid NALU type, expected {:?}, got {:?}",
@@ -4832,7 +4832,7 @@ impl Parser {
     }
 
     /// Parse a PPS NALU.
-    pub fn parse_pps<T: AsRef<[u8]>>(&mut self, nalu: &Nalu<T>) -> anyhow::Result<&Pps> {
+    pub fn parse_pps(&mut self, nalu: &Nalu) -> anyhow::Result<&Pps> {
         if !matches!(nalu.header().type_, NaluType::PpsNut) {
             return Err(anyhow!(
                 "Invalid NALU type, expected {:?}, got {:?}",
@@ -5155,10 +5155,7 @@ impl Parser {
     }
 
     /// Parses a slice header from a slice NALU.
-    pub fn parse_slice_header<T: AsRef<[u8]>>(
-        &mut self,
-        nalu: Nalu<T>,
-    ) -> anyhow::Result<Slice<T>> {
+    pub fn parse_slice_header<'a>(&mut self, nalu: Nalu<'a>) -> anyhow::Result<Slice<'a>> {
         if !matches!(
             nalu.header().type_,
             NaluType::TrailN
@@ -5611,10 +5608,7 @@ mod tests {
     const STREAM_TEST_25_FPS_SLICE_1: &[u8] =
         include_bytes!("test_data/test-25fps-h265-slice-data-1.bin");
 
-    fn dispatch_parse_call(
-        parser: &mut Parser,
-        nalu: Nalu<&[u8], NaluHeader>,
-    ) -> anyhow::Result<()> {
+    fn dispatch_parse_call(parser: &mut Parser, nalu: Nalu<NaluHeader>) -> anyhow::Result<()> {
         match nalu.header().type_ {
             NaluType::TrailN
             | NaluType::TrailR
@@ -5652,9 +5646,9 @@ mod tests {
         bitstream: &[u8],
         nalu_type: NaluType,
         mut nskip: i32,
-    ) -> Option<Nalu<&[u8], NaluHeader>> {
+    ) -> Option<Nalu<NaluHeader>> {
         let mut cursor = Cursor::new(bitstream);
-        while let Ok(nalu) = Nalu::<_, NaluHeader>::next(&mut cursor) {
+        while let Ok(nalu) = Nalu::<NaluHeader>::next(&mut cursor) {
             if nalu.header().type_ == nalu_type {
                 if nskip == 0 {
                     return Some(nalu);
@@ -5672,7 +5666,7 @@ mod tests {
     fn parse_nalus_from_stream_file() {
         let mut cursor = Cursor::new(STREAM_BEAR);
         let mut num_nalus = 0;
-        while Nalu::<_, NaluHeader>::next(&mut cursor).is_ok() {
+        while Nalu::<NaluHeader>::next(&mut cursor).is_ok() {
             num_nalus += 1;
         }
 
@@ -5680,7 +5674,7 @@ mod tests {
 
         let mut cursor = Cursor::new(STREAM_BBB);
         let mut num_nalus = 0;
-        while Nalu::<_, NaluHeader>::next(&mut cursor).is_ok() {
+        while Nalu::<NaluHeader>::next(&mut cursor).is_ok() {
             num_nalus += 1;
         }
 
@@ -5688,7 +5682,7 @@ mod tests {
 
         let mut cursor = Cursor::new(STREAM_TEST25FPS);
         let mut num_nalus = 0;
-        while Nalu::<_, NaluHeader>::next(&mut cursor).is_ok() {
+        while Nalu::<NaluHeader>::next(&mut cursor).is_ok() {
             num_nalus += 1;
         }
 
@@ -5702,21 +5696,21 @@ mod tests {
         let mut cursor = Cursor::new(STREAM_BBB);
         let mut parser = Parser::default();
 
-        while let Ok(nalu) = Nalu::<_, NaluHeader>::next(&mut cursor) {
+        while let Ok(nalu) = Nalu::<NaluHeader>::next(&mut cursor) {
             dispatch_parse_call(&mut parser, nalu).unwrap();
         }
 
         let mut cursor = Cursor::new(STREAM_BEAR);
         let mut parser = Parser::default();
 
-        while let Ok(nalu) = Nalu::<_, NaluHeader>::next(&mut cursor) {
+        while let Ok(nalu) = Nalu::<NaluHeader>::next(&mut cursor) {
             dispatch_parse_call(&mut parser, nalu).unwrap();
         }
 
         let mut cursor = Cursor::new(STREAM_TEST25FPS);
         let mut parser = Parser::default();
 
-        while let Ok(nalu) = Nalu::<_, NaluHeader>::next(&mut cursor) {
+        while let Ok(nalu) = Nalu::<NaluHeader>::next(&mut cursor) {
             dispatch_parse_call(&mut parser, nalu).unwrap();
         }
     }
@@ -5727,7 +5721,7 @@ mod tests {
         let mut cursor = Cursor::new(STREAM_BEAR);
         let mut parser = Parser::default();
 
-        let vps_nalu = Nalu::<_, NaluHeader>::next(&mut cursor).unwrap();
+        let vps_nalu = Nalu::<NaluHeader>::next(&mut cursor).unwrap();
         let vps = parser.parse_vps(&vps_nalu).unwrap();
 
         assert!(vps.base_layer_internal_flag);
@@ -5924,7 +5918,7 @@ mod tests {
         let mut cursor = Cursor::new(STREAM_TEST25FPS);
         let mut parser = Parser::default();
 
-        let vps_nalu = Nalu::<_, NaluHeader>::next(&mut cursor).unwrap();
+        let vps_nalu = Nalu::<NaluHeader>::next(&mut cursor).unwrap();
         let vps = parser.parse_vps(&vps_nalu).unwrap();
         assert!(vps.base_layer_internal_flag);
         assert!(vps.base_layer_available_flag);

--- a/src/codec/h265/picture.rs
+++ b/src/codec/h265/picture.rs
@@ -47,7 +47,7 @@ impl PictureData {
     /// This will also call the picture order count process (clause 8.3.1) to
     /// correctly initialize the POC values.
     pub fn new_from_slice(
-        slice: &Slice<&[u8]>,
+        slice: &Slice,
         pps: &Pps,
         first_picture_in_bitstream: bool,
         first_picture_after_eos: bool,

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -106,7 +106,7 @@ pub trait StatelessH264DecoderBackend: StatelessDecoderBackend<Rc<Sps>> {
     fn decode_slice(
         &mut self,
         picture: &mut Self::Picture,
-        slice: &Slice<&[u8]>,
+        slice: &Slice,
         sps: &Sps,
         pps: &Pps,
         dpb: &Dpb<Self::Handle>,
@@ -546,7 +546,7 @@ where
     #[allow(clippy::type_complexity)]
     fn find_first_field(
         &self,
-        slice: &Slice<impl AsRef<[u8]>>,
+        slice: &Slice,
     ) -> anyhow::Result<Option<(Rc<RefCell<PictureData>>, B::Handle)>> {
         let mut prev_field = None;
 
@@ -1422,7 +1422,7 @@ where
     /// Init the current picture being decoded.
     fn init_current_pic(
         &mut self,
-        slice: &Slice<&[u8]>,
+        slice: &Slice,
         first_field: Option<&Rc<RefCell<PictureData>>>,
         timestamp: u64,
     ) -> anyhow::Result<PictureData> {
@@ -1472,7 +1472,7 @@ where
     fn begin_picture(
         &mut self,
         timestamp: u64,
-        slice: &Slice<&[u8]>,
+        slice: &Slice,
     ) -> Result<CurrentPicState<B>, DecodeError> {
         let nalu_hdr = slice.nalu().header();
 
@@ -1779,7 +1779,7 @@ where
     fn handle_slice(
         &mut self,
         cur_pic: &mut CurrentPicState<B>,
-        slice: &Slice<&[u8]>,
+        slice: &Slice,
     ) -> anyhow::Result<()> {
         // A slice can technically refer to another PPS.
         let pps = self
@@ -1824,7 +1824,7 @@ where
         Ok(handle)
     }
 
-    fn process_nalu(&mut self, timestamp: u64, nalu: Nalu<&[u8]>) -> Result<(), DecodeError> {
+    fn process_nalu(&mut self, timestamp: u64, nalu: Nalu) -> Result<(), DecodeError> {
         match nalu.header().nalu_type() {
             NaluType::Sps => {
                 self.codec.parser.parse_sps(&nalu)?;
@@ -1981,7 +1981,7 @@ pub mod tests {
             |d, s, f| {
                 simple_playback_loop(
                     d,
-                    NalIterator::<Nalu<_>>::new(s),
+                    NalIterator::<Nalu>::new(s),
                     f,
                     &mut simple_playback_loop_owned_frames,
                     DecodedFormat::NV12,

--- a/src/decoder/stateless/h264/dummy.rs
+++ b/src/decoder/stateless/h264/dummy.rs
@@ -51,7 +51,7 @@ impl StatelessH264DecoderBackend for Backend {
     fn decode_slice(
         &mut self,
         _: &mut Self::Picture,
-        _: &Slice<&[u8]>,
+        _: &Slice,
         _: &Sps,
         _: &Pps,
         _: &Dpb<Self::Handle>,

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -499,7 +499,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH264DecoderBackend for Vaapi
     fn decode_slice(
         &mut self,
         picture: &mut Self::Picture,
-        slice: &Slice<&[u8]>,
+        slice: &Slice,
         sps: &Sps,
         pps: &Pps,
         _: &Dpb<Self::Handle>,
@@ -612,7 +612,7 @@ mod tests {
             |d, s, f| {
                 simple_playback_loop(
                     d,
-                    NalIterator::<Nalu<_>>::new(s),
+                    NalIterator::<Nalu>::new(s),
                     f,
                     &mut simple_playback_loop_owned_frames,
                     output_format,

--- a/src/decoder/stateless/h265/dummy.rs
+++ b/src/decoder/stateless/h265/dummy.rs
@@ -40,7 +40,7 @@ impl StatelessH265DecoderBackend for Backend {
         _: &crate::codec::h265::parser::Pps,
         _: &crate::codec::h265::dpb::Dpb<Self::Handle>,
         _: &crate::decoder::stateless::h265::RefPicSet<Self::Handle>,
-        _: &crate::codec::h265::parser::Slice<&[u8]>,
+        _: &crate::codec::h265::parser::Slice,
     ) -> crate::decoder::stateless::StatelessBackendResult<()> {
         Ok(())
     }
@@ -48,7 +48,7 @@ impl StatelessH265DecoderBackend for Backend {
     fn decode_slice(
         &mut self,
         _: &mut Self::Picture,
-        _: &crate::codec::h265::parser::Slice<&[u8]>,
+        _: &crate::codec::h265::parser::Slice,
         _: &crate::codec::h265::parser::Sps,
         _: &crate::codec::h265::parser::Pps,
         _: &crate::codec::h265::dpb::Dpb<Self::Handle>,

--- a/src/decoder/stateless/h265/vaapi.rs
+++ b/src/decoder/stateless/h265/vaapi.rs
@@ -384,7 +384,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> VaapiBackend<BackendData, M> {
     }
 
     fn build_pic_param(
-        _: &Slice<impl AsRef<[u8]>>,
+        _: &Slice,
         current_picture: &PictureData,
         current_surface_id: libva::VASurfaceID,
         dpb: &Dpb<VADecodedHandle<M>>,
@@ -625,7 +625,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH265DecoderBackend
         pps: &Pps,
         dpb: &Dpb<Self::Handle>,
         rps: &RefPicSet<Self::Handle>,
-        slice: &Slice<&[u8]>,
+        slice: &Slice,
     ) -> crate::decoder::stateless::StatelessBackendResult<()> {
         let metadata = self.metadata_state.get_parsed()?;
         let context = &metadata.context;
@@ -677,7 +677,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH265DecoderBackend
     fn decode_slice(
         &mut self,
         picture: &mut Self::Picture,
-        slice: &Slice<&[u8]>,
+        slice: &Slice,
         sps: &Sps,
         _: &Pps,
         _: &Dpb<Self::Handle>,
@@ -885,7 +885,7 @@ mod tests {
             |d, s, f| {
                 simple_playback_loop(
                     d,
-                    NalIterator::<Nalu<_>>::new(s),
+                    NalIterator::<Nalu>::new(s),
                     f,
                     &mut simple_playback_loop_owned_frames,
                     output_format,

--- a/src/decoder/stateless/vp8.rs
+++ b/src/decoder/stateless/vp8.rs
@@ -168,7 +168,7 @@ where
     B::Handle: Clone,
 {
     /// Handle a single frame.
-    fn handle_frame(&mut self, frame: Frame<&[u8]>, timestamp: u64) -> Result<(), DecodeError> {
+    fn handle_frame(&mut self, frame: Frame, timestamp: u64) -> Result<(), DecodeError> {
         if self.backend.frame_pool().num_free_frames() == 0 {
             return Err(DecodeError::NotEnoughOutputBuffers(1));
         }
@@ -201,7 +201,7 @@ where
         Ok(())
     }
 
-    fn negotiation_possible(&self, frame: &Frame<impl AsRef<[u8]>>) -> bool {
+    fn negotiation_possible(&self, frame: &Frame) -> bool {
         let coded_resolution = self.coded_resolution;
         let hdr = &frame.header;
         let width = u32::from(hdr.width);

--- a/src/decoder/stateless/vp9.rs
+++ b/src/decoder/stateless/vp9.rs
@@ -139,7 +139,7 @@ where
     }
 
     /// Handle a single frame.
-    fn handle_frame(&mut self, frame: &Frame<&[u8]>, timestamp: u64) -> Result<(), DecodeError> {
+    fn handle_frame(&mut self, frame: &Frame, timestamp: u64) -> Result<(), DecodeError> {
         let decoded_handle = if frame.header.show_existing_frame {
             // Frame to be shown. Unwrapping must produce a Picture, because the
             // spec mandates frame_to_show_map_idx references a valid entry in

--- a/src/decoder/stateless/vp9/vaapi.rs
+++ b/src/decoder/stateless/vp9/vaapi.rs
@@ -486,7 +486,7 @@ mod tests {
         // FRAME 0
 
         let packet = ivf_iter.next().unwrap();
-        let mut frames = parser.parse_chunk(&packet).unwrap();
+        let mut frames = parser.parse_chunk(packet).unwrap();
         assert_eq!(frames.len(), 1);
         let frame = frames.remove(0);
 
@@ -556,7 +556,7 @@ mod tests {
         // FRAME 1
 
         let packet = ivf_iter.next().unwrap();
-        let mut frames = parser.parse_chunk(&packet).unwrap();
+        let mut frames = parser.parse_chunk(packet).unwrap();
         assert_eq!(frames.len(), 2);
         let frame = frames.remove(0);
         assert_eq!(frame.as_ref().len(), 2390);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,7 +78,7 @@ impl<'a, Nalu> NalIterator<'a, Nalu> {
     }
 }
 
-impl<'a> Iterator for NalIterator<'a, H264Nalu<&[u8]>> {
+impl<'a> Iterator for NalIterator<'a, H264Nalu<'a>> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -92,7 +92,7 @@ impl<'a> Iterator for NalIterator<'a, H264Nalu<&[u8]>> {
     }
 }
 
-impl<'a> Iterator for NalIterator<'a, H265Nalu<&[u8]>> {
+impl<'a> Iterator for NalIterator<'a, H265Nalu<'a>> {
     type Item = &'a [u8];
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
NaluReaders are always short-lived and want to work with a reference, so we can just build them with it and simplify the code.