### PR TITLE
encoder: Add VP9 support and refactor common encoder code

### DIFF
--- a/examples/ccenc.rs
+++ b/examples/ccenc.rs
@@ -14,7 +14,8 @@ use cros_codecs::backend::vaapi::surface_pool::VaSurfacePool;
 use cros_codecs::codec::h264::parser::Profile;
 use cros_codecs::decoder::FramePool;
 use cros_codecs::encoder::stateless::h264::EncoderConfig;
-use cros_codecs::encoder::stateless::h264::StatelessEncoder;
+use cros_codecs::encoder::stateless::h264::H264;
+use cros_codecs::encoder::stateless::StatelessEncoder;
 use cros_codecs::encoder::stateless::StatelessVideoEncoder;
 use cros_codecs::encoder::Bitrate;
 use cros_codecs::encoder::FrameMetadata;
@@ -157,7 +158,7 @@ fn main() {
 
     let display = libva::Display::open().unwrap();
     let fourcc = b"NV12".into();
-    let mut encoder = StatelessEncoder::new_vaapi(
+    let mut encoder = StatelessEncoder::<H264, _, _>::new_vaapi(
         Rc::clone(&display),
         config,
         fourcc,

--- a/src/backend/vaapi/encoder.rs
+++ b/src/backend/vaapi/encoder.rs
@@ -61,7 +61,7 @@ impl Reconstructed {
 pub struct VaapiBackend<M, H>
 where
     M: SurfaceMemoryDescriptor,
-    H: std::borrow::Borrow<Surface<M>>,
+    H: std::borrow::Borrow<Surface<M>> + 'static,
 {
     /// VA config.
     #[allow(dead_code)]

--- a/src/encoder/stateless.rs
+++ b/src/encoder/stateless.rs
@@ -12,6 +12,7 @@ use crate::encoder::FrameMetadata;
 use crate::BlockingMode;
 
 pub mod h264;
+pub mod vp9;
 
 #[derive(Error, Debug)]
 pub enum StatelessBackendError {

--- a/src/encoder/stateless.rs
+++ b/src/encoder/stateless.rs
@@ -179,7 +179,28 @@ pub trait StatelessEncoderBackendImport<Handle, Picture> {
     ) -> StatelessBackendResult<Picture>;
 }
 
-pub trait StatelessCodec {}
+/// Trait helping contain all codec specific and backend specific types
+pub trait StatelessCodecSpecific<Backend>: StatelessCodec
+where
+    Backend: StatelessVideoEncoderBackend<Self>,
+{
+    /// Codec specific representation of frame reference wrapping a backend reference type
+    /// containing a codec specific frame metadata
+    type Reference;
+
+    /// A request type that will be delivered to codec specific stateless encoder backend
+    type Request;
+
+    /// Codec specific [`BackendPromise`] for [`CodedBitstreamBuffer`] wrapping a backend specific
+    /// [`StatelessVideoEncoderBackend::CodedPromise`]
+    type CodedPromise: BackendPromise<Output = CodedBitstreamBuffer>;
+
+    /// Codec specific [`BackendPromise`] for [`StatelessCodecSpecific::Reference`] wrapping a
+    /// backend speficic [`StatelessVideoEncoderBackend::ReconPromise`]
+    type ReferencePromise: BackendPromise<Output = Self::Reference>;
+}
+
+pub trait StatelessCodec: Sized {}
 
 /// Stateless video encoder interface.
 pub trait StatelessVideoEncoder<H> {

--- a/src/encoder/stateless.rs
+++ b/src/encoder/stateless.rs
@@ -179,9 +179,9 @@ pub(super) trait Predictor<Picture, Reference, Request> {
 }
 
 /// Generic trait for stateless encoder backends
-pub trait StatelessVideoEncoderBackend<Codec>
+pub trait StatelessVideoEncoderBackend<Codec>: Sized
 where
-    Codec: StatelessCodec,
+    Codec: StatelessCodec<Self>,
 {
     /// Backend's specific representation of the input frame, transformed with [`import_picture`].
     /// Might be a wrapper of the input handle with additional backend specific data or a copy of
@@ -211,7 +211,7 @@ pub trait StatelessEncoderBackendImport<Handle, Picture> {
 }
 
 /// Trait helping contain all codec specific and backend specific types
-pub trait StatelessCodecSpecific<Backend>: StatelessCodec
+pub trait StatelessCodec<Backend>: Sized
 where
     Backend: StatelessVideoEncoderBackend<Self>,
 {
@@ -230,8 +230,6 @@ where
     /// backend speficic [`StatelessVideoEncoderBackend::ReconPromise`]
     type ReferencePromise: BackendPromise<Output = Self::Reference>;
 }
-
-pub trait StatelessCodec: Sized {}
 
 /// Stateless video encoder interface.
 pub trait StatelessVideoEncoder<Handle> {
@@ -290,21 +288,20 @@ where
 /// Helper aliases for codec and backend specific types
 type Picture<C, B> = <B as StatelessVideoEncoderBackend<C>>::Picture;
 
-type Reference<C, B> = <C as StatelessCodecSpecific<B>>::Reference;
+type Reference<C, B> = <C as StatelessCodec<B>>::Reference;
 
-type Request<C, B> = <C as StatelessCodecSpecific<B>>::Request;
+type Request<C, B> = <C as StatelessCodec<B>>::Request;
 
-type CodedPromise<C, B> = <C as StatelessCodecSpecific<B>>::CodedPromise;
+type CodedPromise<C, B> = <C as StatelessCodec<B>>::CodedPromise;
 
-type ReferencePromise<C, B> =
-    <C as StatelessCodecSpecific<B>>::ReferencePromise;
+type ReferencePromise<C, B> = <C as StatelessCodec<B>>::ReferencePromise;
 
 type BoxPredictor<C, B> = Box<dyn Predictor<Picture<C, B>, Reference<C, B>, Request<C, B>>>;
 
 pub struct StatelessEncoder<Codec, Handle, Backend>
 where
     Backend: StatelessVideoEncoderBackend<Codec>,
-    Codec: StatelessCodec + StatelessCodecSpecific<Backend>,
+    Codec: StatelessCodec<Backend>,
 {
     /// Pending frame output promise queue
     output_queue: OutputQueue<CodedPromise<Codec, Backend>>,
@@ -335,14 +332,14 @@ where
 pub trait StatelessEncoderExecute<Codec, Handle, Backend>
 where
     Backend: StatelessVideoEncoderBackend<Codec>,
-    Codec: StatelessCodec + StatelessCodecSpecific<Backend>,
+    Codec: StatelessCodec<Backend>,
 {
     fn execute(&mut self, request: Request<Codec, Backend>) -> EncodeResult<()>;
 }
 
 impl<Codec, Handle, Backend> StatelessEncoder<Codec, Handle, Backend>
 where
-    Codec: StatelessCodec + StatelessCodecSpecific<Backend>,
+    Codec: StatelessCodec<Backend>,
     Backend: StatelessVideoEncoderBackend<Codec>,
     Self: StatelessEncoderExecute<Codec, Handle, Backend>,
 {
@@ -387,7 +384,7 @@ where
 impl<Codec, Handle, Backend> StatelessVideoEncoder<Handle>
     for StatelessEncoder<Codec, Handle, Backend>
 where
-    Codec: StatelessCodec + StatelessCodecSpecific<Backend>,
+    Codec: StatelessCodec<Backend>,
     Backend: StatelessVideoEncoderBackend<Codec>,
     Backend: StatelessEncoderBackendImport<Handle, Backend::Picture>,
     Self: StatelessEncoderExecute<Codec, Handle, Backend>,

--- a/src/encoder/stateless/h264.rs
+++ b/src/encoder/stateless/h264.rs
@@ -19,6 +19,7 @@ use crate::encoder::stateless::OutputQueue;
 use crate::encoder::stateless::Predictor;
 use crate::encoder::stateless::StatelessBackendResult;
 use crate::encoder::stateless::StatelessCodec;
+use crate::encoder::stateless::StatelessCodecSpecific;
 use crate::encoder::stateless::StatelessEncoderBackendImport;
 use crate::encoder::stateless::StatelessVideoEncoder;
 use crate::encoder::stateless::StatelessVideoEncoderBackend;
@@ -81,7 +82,7 @@ pub(crate) struct DpbEntryMeta {
 
 /// Frame structure used in the backend representing currently encoded frame or references used
 /// for its encoding.
-pub(crate) struct DpbEntry<R> {
+pub struct DpbEntry<R> {
     /// Reconstructed picture
     recon_pic: R,
     /// Decoded picture buffer entry metadata
@@ -123,7 +124,7 @@ pub struct BackendRequest<P, R> {
 
 /// Wrapper type for [`BackendPromise<Output = Vec<u8>>`], with additional
 /// metadata.
-struct SlicePromise<P>
+pub struct SlicePromise<P>
 where
     P: BackendPromise<Output = Vec<u8>>,
 {
@@ -155,7 +156,7 @@ where
 
 /// Wrapper type for [`BackendPromise<Output = R>`], with additional
 /// metadata.
-struct ReferencePromise<P>
+pub struct ReferencePromise<P>
 where
     P: BackendPromise,
 {
@@ -189,6 +190,19 @@ where
 }
 
 pub struct H264;
+
+impl<Backend> StatelessCodecSpecific<Backend> for H264
+where
+    Backend: StatelessVideoEncoderBackend<H264>,
+{
+    type Reference = DpbEntry<Backend::Reconstructed>;
+
+    type Request = BackendRequest<Backend::Picture, Backend::Reconstructed>;
+
+    type CodedPromise = SlicePromise<Backend::CodedPromise>;
+
+    type ReferencePromise = ReferencePromise<Backend::ReconPromise>;
+}
 
 impl StatelessCodec for H264 {}
 

--- a/src/encoder/stateless/h264.rs
+++ b/src/encoder/stateless/h264.rs
@@ -18,7 +18,6 @@ use crate::encoder::stateless::FrameMetadata;
 use crate::encoder::stateless::Predictor;
 use crate::encoder::stateless::StatelessBackendResult;
 use crate::encoder::stateless::StatelessCodec;
-use crate::encoder::stateless::StatelessCodecSpecific;
 use crate::encoder::stateless::StatelessEncoder;
 use crate::encoder::stateless::StatelessEncoderBackendImport;
 use crate::encoder::stateless::StatelessEncoderExecute;
@@ -158,7 +157,7 @@ where
 
 pub struct H264;
 
-impl<Backend> StatelessCodecSpecific<Backend> for H264
+impl<Backend> StatelessCodec<Backend> for H264
 where
     Backend: StatelessVideoEncoderBackend<H264>,
 {
@@ -170,8 +169,6 @@ where
 
     type ReferencePromise = ReferencePromise<Backend::ReconPromise>;
 }
-
-impl StatelessCodec for H264 {}
 
 /// Trait for stateless encoder backend for H.264
 pub trait StatelessH264EncoderBackend: StatelessVideoEncoderBackend<H264> {

--- a/src/encoder/stateless/vp9.rs
+++ b/src/encoder/stateless/vp9.rs
@@ -1,0 +1,147 @@
+// Copyright 2024 The ChromiumOS Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::rc::Rc;
+
+use crate::codec::vp9::parser::Header;
+use crate::encoder::stateless::vp9::predictor::LowDelay;
+pub use crate::encoder::stateless::vp9::predictor::PredictionStructure;
+use crate::encoder::stateless::BitstreamPromise;
+use crate::encoder::stateless::EncodeResult;
+use crate::encoder::stateless::Predictor;
+use crate::encoder::stateless::StatelessBackendResult;
+use crate::encoder::stateless::StatelessCodec;
+use crate::encoder::stateless::StatelessCodecSpecific;
+use crate::encoder::stateless::StatelessEncoder;
+use crate::encoder::stateless::StatelessEncoderExecute;
+use crate::encoder::stateless::StatelessVideoEncoderBackend;
+use crate::encoder::Bitrate;
+use crate::encoder::FrameMetadata;
+use crate::BlockingMode;
+use crate::Resolution;
+
+mod predictor;
+
+#[cfg(feature = "vaapi")]
+pub mod vaapi;
+
+#[derive(Clone)]
+pub struct EncoderConfig {
+    pub bitrate: Bitrate,
+    pub framerate: u32,
+    pub resolution: Resolution,
+    pub pred_structure: PredictionStructure,
+}
+
+impl Default for EncoderConfig {
+    fn default() -> Self {
+        // Artificially encoder configuration with intent to be widely supported.
+        Self {
+            bitrate: Bitrate::Constant(30_000_000),
+            framerate: 30,
+            resolution: Resolution {
+                width: 320,
+                height: 240,
+            },
+            pred_structure: PredictionStructure::LowDelay { limit: 2048 },
+        }
+    }
+}
+
+/// Determines how reference frame shall be used
+pub enum ReferenceUse {
+    /// The frame will be used for single prediction
+    Single,
+    /// The frame will be used for compound prediction
+    Compound,
+    /// The frame will be used for both single and compound prediction
+    Hybrid,
+}
+
+pub struct BackendRequest<P, R> {
+    header: Header,
+
+    /// Input frame to be encoded
+    input: P,
+
+    /// Input frame metadata
+    input_meta: FrameMetadata,
+
+    /// Reference frames
+    last_frame_ref: Option<(Rc<R>, ReferenceUse)>,
+    golden_frame_ref: Option<(Rc<R>, ReferenceUse)>,
+    altref_frame_ref: Option<(Rc<R>, ReferenceUse)>,
+
+    /// Current expected bitrate
+    bitrate: Bitrate,
+
+    /// Container for the request output. [`StatelessVP9EncoderBackend`] impl shall move it and
+    /// append the slice data to it. This prevents unnecessary copying of bitstream around.
+    coded_output: Vec<u8>,
+}
+
+pub struct VP9;
+
+impl<Backend> StatelessCodecSpecific<Backend> for VP9
+where
+    Backend: StatelessVideoEncoderBackend<VP9>,
+{
+    type Reference = Backend::Reconstructed;
+
+    type Request = BackendRequest<Backend::Picture, Backend::Reconstructed>;
+
+    type CodedPromise = BitstreamPromise<Backend::CodedPromise>;
+
+    type ReferencePromise = Backend::ReconPromise;
+}
+
+impl StatelessCodec for VP9 {}
+
+pub trait StatelessVP9EncoderBackend: StatelessVideoEncoderBackend<VP9> {
+    fn encode_frame(
+        &mut self,
+        request: BackendRequest<Self::Picture, Self::Reconstructed>,
+    ) -> StatelessBackendResult<(Self::ReconPromise, Self::CodedPromise)>;
+}
+
+impl<Handle, Backend> StatelessEncoderExecute<VP9, Handle, Backend>
+    for StatelessEncoder<VP9, Handle, Backend>
+where
+    Backend: StatelessVP9EncoderBackend,
+{
+    fn execute(
+        &mut self,
+        request: BackendRequest<Backend::Picture, Backend::Reconstructed>,
+    ) -> EncodeResult<()> {
+        let meta = request.input_meta.clone();
+
+        // The [`BackendRequest`] has a frame from predictor. Decresing internal counter.
+        self.predictor_frame_count -= 1;
+
+        log::trace!("submitting new request");
+        let (recon, bitstream) = self.backend.encode_frame(request)?;
+
+        // Wrap promise from backend with headers and metadata
+        let slice_promise = BitstreamPromise { bitstream, meta };
+
+        self.output_queue.add_promise(slice_promise);
+
+        self.recon_queue.add_promise(recon);
+
+        Ok(())
+    }
+}
+
+impl<Handle, Backend> StatelessEncoder<VP9, Handle, Backend>
+where
+    Backend: StatelessVP9EncoderBackend,
+{
+    fn new_vp9(backend: Backend, config: EncoderConfig, mode: BlockingMode) -> EncodeResult<Self> {
+        let predictor: Box<dyn Predictor<_, _, _>> = match config.pred_structure {
+            PredictionStructure::LowDelay { .. } => Box::new(LowDelay::new(config)),
+        };
+
+        Self::new(backend, mode, predictor)
+    }
+}

--- a/src/encoder/stateless/vp9.rs
+++ b/src/encoder/stateless/vp9.rs
@@ -12,7 +12,6 @@ use crate::encoder::stateless::EncodeResult;
 use crate::encoder::stateless::Predictor;
 use crate::encoder::stateless::StatelessBackendResult;
 use crate::encoder::stateless::StatelessCodec;
-use crate::encoder::stateless::StatelessCodecSpecific;
 use crate::encoder::stateless::StatelessEncoder;
 use crate::encoder::stateless::StatelessEncoderExecute;
 use crate::encoder::stateless::StatelessVideoEncoderBackend;
@@ -83,7 +82,7 @@ pub struct BackendRequest<P, R> {
 
 pub struct VP9;
 
-impl<Backend> StatelessCodecSpecific<Backend> for VP9
+impl<Backend> StatelessCodec<Backend> for VP9
 where
     Backend: StatelessVideoEncoderBackend<VP9>,
 {
@@ -95,8 +94,6 @@ where
 
     type ReferencePromise = Backend::ReconPromise;
 }
-
-impl StatelessCodec for VP9 {}
 
 pub trait StatelessVP9EncoderBackend: StatelessVideoEncoderBackend<VP9> {
     fn encode_frame(

--- a/src/encoder/stateless/vp9/predictor.rs
+++ b/src/encoder/stateless/vp9/predictor.rs
@@ -1,0 +1,169 @@
+// Copyright 2024 The ChromiumOS Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::collections::VecDeque;
+use std::rc::Rc;
+
+use super::BackendRequest;
+use super::EncoderConfig;
+use crate::codec::vp9::parser::FrameType;
+use crate::codec::vp9::parser::Header;
+use crate::encoder::stateless::vp9::ReferenceUse;
+use crate::encoder::stateless::EncodeError;
+use crate::encoder::stateless::EncodeResult;
+use crate::encoder::stateless::Predictor;
+use crate::encoder::FrameMetadata;
+
+#[derive(Clone)]
+pub enum PredictionStructure {
+    /// Simplest prediction structure, suitable eg. for RTC. Interframe is produced at the start of
+    /// the stream and every time when [`limit`] frames are reached. Following interframe frames
+    /// are frames relying solely on the last frame.
+    LowDelay { limit: u16 },
+}
+
+/// See [`PredictionStructure::LowDelay`]
+pub(super) struct LowDelay<P, R> {
+    queue: VecDeque<(P, FrameMetadata)>,
+
+    references: VecDeque<Rc<R>>,
+
+    counter: usize,
+
+    /// Encoder config
+    config: EncoderConfig,
+}
+
+impl<P, R> LowDelay<P, R> {
+    pub(super) fn new(config: EncoderConfig) -> Self {
+        Self {
+            queue: Default::default(),
+            references: Default::default(),
+            counter: 0,
+            config,
+        }
+    }
+
+    fn request_keyframe(
+        &mut self,
+        input: P,
+        input_meta: FrameMetadata,
+    ) -> EncodeResult<Vec<BackendRequest<P, R>>> {
+        log::trace!("Requested keyframe timestamp={}", input_meta.timestamp);
+
+        let header = Header {
+            frame_type: FrameType::KeyFrame,
+            show_frame: true,
+            error_resilient_mode: true,
+            width: self.config.resolution.width,
+            height: self.config.resolution.height,
+            render_and_frame_size_different: false,
+            render_width: self.config.resolution.width,
+            render_height: self.config.resolution.height,
+            intra_only: true,
+            refresh_frame_flags: 0x01,
+            ref_frame_idx: [0, 0, 0],
+
+            ..Default::default()
+        };
+
+        let request = BackendRequest {
+            header,
+            input,
+            input_meta,
+            last_frame_ref: None,
+            golden_frame_ref: None,
+            altref_frame_ref: None,
+            bitrate: self.config.bitrate.clone(),
+            coded_output: Vec::new(),
+        };
+
+        self.counter += 1;
+
+        Ok(vec![request])
+    }
+
+    fn request_interframe(
+        &mut self,
+        input: P,
+        input_meta: FrameMetadata,
+    ) -> EncodeResult<Vec<BackendRequest<P, R>>> {
+        log::trace!("Requested interframe timestamp={}", input_meta.timestamp);
+
+        let header = Header {
+            frame_type: FrameType::InterFrame,
+            show_frame: true,
+            error_resilient_mode: true,
+            width: self.config.resolution.width,
+            height: self.config.resolution.height,
+            render_and_frame_size_different: false,
+            render_width: self.config.resolution.width,
+            render_height: self.config.resolution.height,
+            intra_only: false,
+            refresh_frame_flags: 0x01,
+            ref_frame_idx: [0; 3],
+
+            ..Default::default()
+        };
+
+        let ref_frame = self.references.pop_front().unwrap();
+
+        let request = BackendRequest {
+            header,
+            input,
+            input_meta,
+            last_frame_ref: Some((ref_frame, ReferenceUse::Single)),
+            golden_frame_ref: None,
+            altref_frame_ref: None,
+            bitrate: self.config.bitrate.clone(),
+            coded_output: Vec::new(),
+        };
+
+        self.counter += 1;
+        self.references.clear();
+
+        Ok(vec![request])
+    }
+
+    fn next_request(&mut self) -> EncodeResult<Vec<BackendRequest<P, R>>> {
+        match self.queue.pop_front() {
+            // Nothing to do. Quit.
+            None => Ok(Vec::new()),
+            // If first frame in the sequence or forced IDR then create IDR request.
+            Some((input, meta)) if self.counter == 0 || meta.force_keyframe => {
+                self.request_keyframe(input, meta)
+            }
+            // There is no enough frames reconstructed
+            Some((input, meta)) if self.references.is_empty() => {
+                self.queue.push_front((input, meta));
+                Ok(Vec::new())
+            }
+
+            Some((input, meta)) => self.request_interframe(input, meta),
+        }
+    }
+}
+
+impl<P, R> Predictor<P, R, BackendRequest<P, R>> for LowDelay<P, R> {
+    fn new_frame(
+        &mut self,
+        input: P,
+        frame_metadata: FrameMetadata,
+    ) -> EncodeResult<Vec<BackendRequest<P, R>>> {
+        // Add new frame in the request queue and request new encoding if possible
+        self.queue.push_back((input, frame_metadata));
+        self.next_request()
+    }
+
+    fn reconstructed(&mut self, recon: R) -> EncodeResult<Vec<BackendRequest<P, R>>> {
+        // Add new reconstructed surface and request next encoding if possible
+        self.references.push_back(Rc::new(recon));
+        self.next_request()
+    }
+
+    fn drain(&mut self) -> EncodeResult<Vec<BackendRequest<P, R>>> {
+        // [`LowDelay`] will not hold any frames, therefore the drain function shall never be called.
+        Err(EncodeError::InvalidInternalState)
+    }
+}

--- a/src/encoder/stateless/vp9/vaapi.rs
+++ b/src/encoder/stateless/vp9/vaapi.rs
@@ -1,0 +1,556 @@
+// Copyright 2024 The ChromiumOS Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+use std::any::Any;
+use std::borrow::Borrow;
+use std::rc::Rc;
+
+use anyhow::Context;
+use libva::constants::VA_INVALID_SURFACE;
+use libva::BufferType;
+use libva::Display;
+use libva::EncPictureParameter;
+use libva::EncPictureParameterBufferVP9;
+use libva::EncSequenceParameter;
+use libva::EncSequenceParameterBufferVP9;
+use libva::Picture;
+use libva::Surface;
+use libva::SurfaceMemoryDescriptor;
+use libva::VAProfile::VAProfileVP9Profile0;
+use libva::VP9EncPicFlags;
+use libva::VP9EncRefFlags;
+
+use crate::backend::vaapi::encoder::CodedOutputPromise;
+use crate::backend::vaapi::encoder::Reconstructed;
+use crate::backend::vaapi::encoder::VaapiBackend;
+use crate::codec::vp9::parser::FrameType;
+use crate::codec::vp9::parser::InterpolationFilter;
+use crate::codec::vp9::parser::ALTREF_FRAME;
+use crate::codec::vp9::parser::GOLDEN_FRAME;
+use crate::codec::vp9::parser::LAST_FRAME;
+use crate::codec::vp9::parser::NUM_REF_FRAMES;
+use crate::encoder::stateless::vp9::BackendRequest;
+use crate::encoder::stateless::vp9::EncoderConfig;
+use crate::encoder::stateless::vp9::ReferenceUse;
+use crate::encoder::stateless::vp9::StatelessEncoder;
+use crate::encoder::stateless::vp9::StatelessVP9EncoderBackend;
+use crate::encoder::stateless::vp9::VP9;
+use crate::encoder::stateless::EncodeResult;
+use crate::encoder::stateless::ReadyPromise;
+use crate::encoder::stateless::StatelessBackendResult;
+use crate::encoder::stateless::StatelessVideoEncoderBackend;
+use crate::encoder::Bitrate;
+use crate::BlockingMode;
+use crate::Fourcc;
+use crate::Resolution;
+
+impl<M, Handle> StatelessVideoEncoderBackend<VP9> for VaapiBackend<M, Handle>
+where
+    M: SurfaceMemoryDescriptor,
+    Handle: Borrow<Surface<M>>,
+{
+    type Picture = Handle;
+    type Reconstructed = Reconstructed;
+    type CodedPromise = CodedOutputPromise<M, Handle>;
+    type ReconPromise = ReadyPromise<Self::Reconstructed>;
+}
+
+impl<M, Handle> StatelessVP9EncoderBackend for VaapiBackend<M, Handle>
+where
+    M: SurfaceMemoryDescriptor,
+    Handle: Borrow<Surface<M>>,
+{
+    fn encode_frame(
+        &mut self,
+        request: BackendRequest<Self::Picture, Self::Reconstructed>,
+    ) -> StatelessBackendResult<(Self::ReconPromise, Self::CodedPromise)> {
+        // Coded buffer size multiplier. It's inteded to give head room for the encoder.
+        const CODED_SIZE_MUL: usize = 2;
+
+        let coded_buf = self
+            .context()
+            .create_enc_coded(CODED_SIZE_MUL * request.bitrate.target() as usize)?;
+
+        let recon = self.new_scratch_picture()?;
+
+        let seq_param = BufferType::EncSequenceParameter(EncSequenceParameter::VP9(
+            EncSequenceParameterBufferVP9::new(
+                request.input_meta.display_resolution.width,
+                request.input_meta.display_resolution.height,
+                0,
+                10,
+                2000,
+                request.bitrate.target() as u32,
+                1024,
+            ),
+        ));
+
+        // From va_enc_vp9.h `ref_frame_ctrl_l0` documentation
+        const LAST_FRAME_AS_REF: u32 = 0x01;
+        const GOLDEN_FRAME_AS_REF: u32 = 0x02;
+        const ALTREF_FRAME_AS_REF: u32 = 0x04;
+
+        let mut references = Vec::<Rc<dyn Any>>::new();
+        let mut reference_frames = [VA_INVALID_SURFACE; NUM_REF_FRAMES];
+
+        let mut ref_frame_ctrl_l0 = 0;
+        let mut ref_frame_ctrl_l1 = 0;
+
+        let refs = [
+            (&request.last_frame_ref, LAST_FRAME - 1, LAST_FRAME_AS_REF),
+            (
+                &request.golden_frame_ref,
+                GOLDEN_FRAME - 1,
+                GOLDEN_FRAME_AS_REF,
+            ),
+            (
+                &request.altref_frame_ref,
+                ALTREF_FRAME - 1,
+                ALTREF_FRAME_AS_REF,
+            ),
+        ];
+
+        for (r, ref_idx, ref_ctrl) in refs {
+            let Some((ref_frame, ref_use)) = r else {
+                continue;
+            };
+
+            reference_frames[request.header.ref_frame_idx[ref_idx] as usize] =
+                ref_frame.surface_id();
+            references.push(ref_frame.clone());
+
+            match ref_use {
+                ReferenceUse::Single => ref_frame_ctrl_l0 |= ref_ctrl,
+                ReferenceUse::Compound => ref_frame_ctrl_l1 |= ref_ctrl,
+                ReferenceUse::Hybrid => {
+                    ref_frame_ctrl_l0 |= ref_ctrl;
+                    ref_frame_ctrl_l1 |= ref_ctrl;
+                }
+            }
+        }
+
+        let force_kf =
+            request.header.frame_type == FrameType::KeyFrame || request.input_meta.force_keyframe;
+
+        let ref_flags = VP9EncRefFlags::new(
+            // Force keyframe if requested
+            force_kf as u32,
+            ref_frame_ctrl_l0,
+            ref_frame_ctrl_l1,
+            request.header.ref_frame_idx[LAST_FRAME - 1] as u32,
+            request.header.ref_frame_sign_bias[LAST_FRAME] as u32,
+            request.header.ref_frame_idx[GOLDEN_FRAME - 1] as u32,
+            request.header.ref_frame_sign_bias[GOLDEN_FRAME] as u32,
+            request.header.ref_frame_idx[ALTREF_FRAME - 1] as u32,
+            request.header.ref_frame_sign_bias[ALTREF_FRAME] as u32,
+            0,
+        );
+
+        // From va_enc_vp9.h `mcomp_filter_type` documentation
+        let mcomp_filter_type = match request.header.interpolation_filter {
+            InterpolationFilter::EightTap => 0,
+            InterpolationFilter::EightTapSmooth => 1,
+            InterpolationFilter::EightTapSharp => 2,
+            InterpolationFilter::Bilinear => 3,
+            InterpolationFilter::Switchable => 4,
+        };
+
+        // TODO: show_existing_frame
+        assert!(!request.header.show_existing_frame);
+
+        // From va_enc_vp9.h `comp_prediction_mode` documentation
+        const PRED_MODE_SINGLE: u32 = 0x00;
+        // const PRED_MODE_COMPOUND: u32 = 0x01;
+        const PRED_MODE_HYBRID: u32 = 0x02;
+
+        let comp_prediction_mode = if ref_frame_ctrl_l1 != 0 {
+            // Use hybrid prediction mode if any future reference frame are enabled
+            PRED_MODE_HYBRID
+        } else {
+            PRED_MODE_SINGLE
+        };
+
+        let pic_flags = VP9EncPicFlags::new(
+            request.header.frame_type as u32,
+            request.header.show_frame as u32,
+            request.header.error_resilient_mode as u32,
+            request.header.intra_only as u32,
+            request.header.allow_high_precision_mv as u32,
+            mcomp_filter_type,
+            request.header.frame_parallel_decoding_mode as u32,
+            request.header.reset_frame_context as u32,
+            request.header.refresh_frame_context as u32,
+            request.header.frame_context_idx as u32,
+            request.header.seg.enabled as u32,
+            request.header.seg.temporal_update as u32,
+            request.header.seg.update_map as u32,
+            request.header.lossless as u32,
+            comp_prediction_mode,
+            1,
+            0,
+        );
+
+        let pic_param = BufferType::EncPictureParameter(EncPictureParameter::VP9(
+            EncPictureParameterBufferVP9::new(
+                request.header.width,
+                request.header.height,
+                request.header.render_width,
+                request.header.render_height,
+                recon.surface_id(),
+                reference_frames,
+                coded_buf.id(),
+                &ref_flags,
+                &pic_flags,
+                request.header.refresh_frame_flags,
+                request.header.quant.base_q_idx,
+                request.header.quant.delta_q_y_dc,
+                request.header.quant.delta_q_uv_ac,
+                request.header.quant.delta_q_uv_dc,
+                request.header.lf.level,
+                request.header.lf.sharpness,
+                request.header.lf.ref_deltas,
+                request.header.lf.mode_deltas,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                request.header.tile_rows_log2,
+                request.header.tile_cols_log2,
+                // Don't skip frames
+                0,
+                0,
+                0,
+            ),
+        ));
+
+        let mut picture = Picture::new(
+            request.input_meta.timestamp,
+            Rc::clone(self.context()),
+            request.input,
+        );
+
+        picture.add_buffer(self.context().create_buffer(seq_param)?);
+        picture.add_buffer(self.context().create_buffer(pic_param)?);
+
+        // Start processing the picture encoding
+        let picture = picture.begin().context("picture begin")?;
+        let picture = picture.render().context("picture render")?;
+        let picture = picture.end().context("picture end")?;
+
+        // libva will handle the synchronization of reconstructed surface with implicit fences.
+        // Therefore return the reconstructed frame immediately.
+        let reference_promise = ReadyPromise::from(recon);
+
+        let bitstream_promise =
+            CodedOutputPromise::new(picture, references, coded_buf, request.coded_output);
+
+        Ok((reference_promise, bitstream_promise))
+    }
+}
+
+impl<M, Handle> StatelessEncoder<VP9, Handle, VaapiBackend<M, Handle>>
+where
+    M: SurfaceMemoryDescriptor,
+    Handle: Borrow<Surface<M>>,
+{
+    pub fn new_vaapi(
+        display: Rc<Display>,
+        config: EncoderConfig,
+        fourcc: Fourcc,
+        coded_size: Resolution,
+        low_power: bool,
+        blocking_mode: BlockingMode,
+    ) -> EncodeResult<Self> {
+        let bitrate_control = match config.bitrate {
+            Bitrate::Constant(_) => libva::constants::VA_RC_CBR,
+        };
+
+        let backend = VaapiBackend::new(
+            display,
+            VAProfileVP9Profile0,
+            fourcc,
+            coded_size,
+            bitrate_control,
+            low_power,
+        )?;
+        Self::new_vp9(backend, config, blocking_mode)
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    use std::rc::Rc;
+
+    use libva::constants::VA_RT_FORMAT_YUV420;
+    use libva::Display;
+    use libva::UsageHint;
+    use libva::VAEntrypoint::VAEntrypointEncSliceLP;
+    use libva::VAProfile::VAProfileVP9Profile0;
+
+    use super::*;
+    use crate::backend::vaapi::encoder::tests::upload_test_frame;
+    use crate::backend::vaapi::encoder::tests::TestFrameGenerator;
+    use crate::backend::vaapi::encoder::VaapiBackend;
+    use crate::backend::vaapi::surface_pool::PooledVaSurface;
+    use crate::backend::vaapi::surface_pool::VaSurfacePool;
+    use crate::codec::vp9::parser::Header;
+    use crate::decoder::FramePool;
+    use crate::encoder::stateless::simple_encode_loop;
+    use crate::encoder::stateless::vp9::BackendRequest;
+    use crate::encoder::stateless::vp9::EncoderConfig;
+    use crate::encoder::stateless::vp9::StatelessEncoder;
+    use crate::encoder::stateless::BackendPromise;
+    use crate::encoder::stateless::StatelessEncoderBackendImport;
+    use crate::encoder::FrameMetadata;
+    use crate::utils::IvfFileHeader;
+    use crate::utils::IvfFrameHeader;
+    use crate::FrameLayout;
+    use crate::PlaneLayout;
+    use crate::Resolution;
+
+    #[test]
+    // Ignore this test by default as it requires libva-compatible hardware.
+    #[ignore]
+    fn test_simple_encode_frame() {
+        type Descriptor = ();
+        type Surface = libva::Surface<Descriptor>;
+        const WIDTH: u32 = 256;
+        const HEIGHT: u32 = 256;
+        let fourcc = b"NV12".into();
+
+        let frame_layout = FrameLayout {
+            format: (fourcc, 0),
+            size: Resolution {
+                width: WIDTH,
+                height: HEIGHT,
+            },
+            planes: vec![
+                PlaneLayout {
+                    buffer_index: 0,
+                    offset: 0,
+                    stride: WIDTH as usize,
+                },
+                PlaneLayout {
+                    buffer_index: 0,
+                    offset: (WIDTH * HEIGHT) as usize,
+                    stride: WIDTH as usize,
+                },
+            ],
+        };
+
+        let display = Display::open().unwrap();
+        let entrypoints = display
+            .query_config_entrypoints(VAProfileVP9Profile0)
+            .unwrap();
+        let low_power = entrypoints.contains(&VAEntrypointEncSliceLP);
+
+        let mut backend = VaapiBackend::<Descriptor, Surface>::new(
+            Rc::clone(&display),
+            VAProfileVP9Profile0,
+            fourcc,
+            Resolution {
+                width: WIDTH,
+                height: HEIGHT,
+            },
+            libva::constants::VA_RC_CBR,
+            low_power,
+        )
+        .unwrap();
+
+        let mut surfaces = display
+            .create_surfaces(
+                VA_RT_FORMAT_YUV420,
+                Some(frame_layout.format.0 .0),
+                WIDTH,
+                HEIGHT,
+                Some(UsageHint::USAGE_HINT_ENCODER),
+                vec![()],
+            )
+            .unwrap();
+
+        let surface = surfaces.pop().unwrap();
+
+        upload_test_frame(&display, &surface, 0.0);
+
+        let input_meta = FrameMetadata {
+            display_resolution: Resolution {
+                width: WIDTH,
+                height: HEIGHT,
+            },
+            layout: frame_layout,
+            force_keyframe: false,
+            timestamp: 0,
+        };
+
+        let pic = backend.import_picture(&input_meta, surface).unwrap();
+
+        let header = Header {
+            frame_type: FrameType::KeyFrame,
+            show_frame: true,
+            error_resilient_mode: false,
+            width: WIDTH,
+            height: HEIGHT,
+            render_and_frame_size_different: false,
+            render_width: WIDTH,
+            render_height: HEIGHT,
+            intra_only: true,
+            refresh_frame_flags: 0x01,
+            ref_frame_idx: [0, 0, 0],
+
+            ..Default::default()
+        };
+
+        let request = BackendRequest {
+            header,
+            input: pic,
+            input_meta,
+            last_frame_ref: None,
+            golden_frame_ref: None,
+            altref_frame_ref: None,
+            bitrate: Bitrate::Constant(30_000),
+            coded_output: Vec::new(),
+        };
+
+        let (_, output) = backend.encode_frame(request).unwrap();
+        let output = output.sync().unwrap();
+
+        let write_to_file = std::option_env!("CROS_CODECS_TEST_WRITE_TO_FILE") == Some("true");
+        if write_to_file {
+            use std::io::Write;
+
+            let mut out = std::fs::File::create("test_simple_encode_frame.vp9.ivf").unwrap();
+
+            let file_header =
+                IvfFileHeader::new(IvfFileHeader::CODEC_VP9, WIDTH as u16, HEIGHT as u16, 30, 1);
+
+            let frame_header = IvfFrameHeader {
+                frame_size: output.len() as u32,
+                timestamp: 0,
+            };
+
+            file_header.writo_into(&mut out).unwrap();
+            frame_header.writo_into(&mut out).unwrap();
+
+            out.write_all(&output).unwrap();
+            out.flush().unwrap();
+        }
+    }
+
+    #[test]
+    // Ignore this test by default as it requires libva-compatible hardware.
+    #[ignore]
+    fn test_vaapi_encoder() {
+        type VaapiVp9Encoder<'l> =
+            StatelessEncoder<VP9, PooledVaSurface<()>, VaapiBackend<(), PooledVaSurface<()>>>;
+
+        const WIDTH: usize = 512;
+        const HEIGHT: usize = 512;
+        const FRAME_COUNT: u64 = 100;
+
+        let _ = env_logger::try_init();
+
+        let display = libva::Display::open().unwrap();
+        let entrypoints = display
+            .query_config_entrypoints(VAProfileVP9Profile0)
+            .unwrap();
+        let low_power = entrypoints.contains(&VAEntrypointEncSliceLP);
+
+        let config = EncoderConfig {
+            bitrate: Bitrate::Constant(200_000),
+            framerate: 30,
+            resolution: Resolution {
+                width: WIDTH as u32,
+                height: HEIGHT as u32,
+            },
+            ..Default::default()
+        };
+
+        let frame_layout = FrameLayout {
+            format: (b"NV12".into(), 0),
+            size: Resolution {
+                width: WIDTH as u32,
+                height: HEIGHT as u32,
+            },
+            planes: vec![
+                PlaneLayout {
+                    buffer_index: 0,
+                    offset: 0,
+                    stride: WIDTH,
+                },
+                PlaneLayout {
+                    buffer_index: 0,
+                    offset: WIDTH * HEIGHT,
+                    stride: WIDTH,
+                },
+            ],
+        };
+
+        let mut encoder = VaapiVp9Encoder::new_vaapi(
+            Rc::clone(&display),
+            config,
+            frame_layout.format.0,
+            frame_layout.size,
+            low_power,
+            BlockingMode::Blocking,
+        )
+        .unwrap();
+
+        let mut pool = VaSurfacePool::new(
+            Rc::clone(&display),
+            VA_RT_FORMAT_YUV420,
+            Some(UsageHint::USAGE_HINT_ENCODER),
+            Resolution {
+                width: WIDTH as u32,
+                height: HEIGHT as u32,
+            },
+        );
+
+        pool.add_frames(vec![(); 16]).unwrap();
+
+        let mut frame_producer = TestFrameGenerator::new(
+            FRAME_COUNT,
+            display,
+            pool,
+            Resolution {
+                width: WIDTH as u32,
+                height: HEIGHT as u32,
+            },
+            frame_layout,
+        );
+
+        let mut bitstream = Vec::new();
+
+        let file_header = IvfFileHeader::new(
+            IvfFileHeader::CODEC_VP9,
+            WIDTH as u16,
+            HEIGHT as u16,
+            30,
+            FRAME_COUNT as u32,
+        );
+
+        file_header.writo_into(&mut bitstream).unwrap();
+
+        simple_encode_loop(&mut encoder, &mut frame_producer, |coded| {
+            let header = IvfFrameHeader {
+                timestamp: coded.metadata.timestamp,
+                frame_size: coded.bitstream.len() as u32,
+            };
+
+            header.writo_into(&mut bitstream).unwrap();
+            bitstream.extend(coded.bitstream);
+        })
+        .unwrap();
+
+        let write_to_file = std::option_env!("CROS_CODECS_TEST_WRITE_TO_FILE") == Some("true");
+        if write_to_file {
+            use std::io::Write;
+            let mut out = std::fs::File::create("test_vaapi_encoder.vp9.ivf").unwrap();
+            out.write_all(&bitstream).unwrap();
+            out.flush().unwrap();
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -367,3 +367,80 @@ impl Drop for UserPtrFrame {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ivf_file_header() {
+        let mut hdr = IvfFileHeader {
+            version: 0,
+            codec: IvfFileHeader::CODEC_VP9,
+            width: 256,
+            height: 256,
+            framerate: 30_000,
+            timescale: 1_000,
+            frame_count: 1,
+
+            ..Default::default()
+        };
+
+        let mut buf = Vec::new();
+        hdr.writo_into(&mut buf).unwrap();
+
+        const EXPECTED: [u8; 32] = [
+            0x44, 0x4b, 0x49, 0x46, 0x00, 0x00, 0x20, 0x00, 0x56, 0x50, 0x39, 0x30, 0x00, 0x01,
+            0x00, 0x01, 0x30, 0x75, 0x00, 0x00, 0xe8, 0x03, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+
+        assert_eq!(&buf, &EXPECTED);
+
+        hdr.width = 1920;
+        hdr.height = 800;
+        hdr.framerate = 24;
+        hdr.timescale = 1;
+        hdr.frame_count = 100;
+
+        buf.clear();
+        hdr.writo_into(&mut buf).unwrap();
+
+        const EXPECTED2: [u8; 32] = [
+            0x44, 0x4b, 0x49, 0x46, 0x00, 0x00, 0x20, 0x00, 0x56, 0x50, 0x39, 0x30, 0x80, 0x07,
+            0x20, 0x03, 0x18, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ];
+
+        assert_eq!(&buf, &EXPECTED2);
+    }
+
+    #[test]
+    fn test_ivf_frame_header() {
+        let mut hdr = IvfFrameHeader {
+            frame_size: 199249,
+            timestamp: 0,
+        };
+
+        let mut buf = Vec::new();
+        hdr.writo_into(&mut buf).unwrap();
+
+        const EXPECTED: [u8; 12] = [
+            0x51, 0x0a, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        assert_eq!(&buf, &EXPECTED);
+
+        hdr.timestamp = 1;
+        hdr.frame_size = 52;
+
+        buf.clear();
+        hdr.writo_into(&mut buf).unwrap();
+
+        const EXPECTED2: [u8; 12] = [
+            0x34, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+
+        assert_eq!(&buf, &EXPECTED2);
+    }
+}


### PR DESCRIPTION
This PR adds VP9 encoding support and refactors the common encoder code to remove code duplication between codecs.  