### PR TITLE
decoder: H264 improvements

### DIFF
--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -334,8 +334,9 @@ impl<T: Clone> Dpb<T> {
         } else {
             self.pictures()
                 .filter(|pic| {
-                    !pic.is_second_field()
-                        && (matches!(pic.field, Field::Frame) || pic.other_field().is_some())
+                    matches!(pic.field_rank(), FieldRank::First(..))
+                        || (matches!(pic.field_rank(), FieldRank::Single)
+                            && pic.field == Field::Frame)
                 })
                 .count()
         };

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -527,7 +527,11 @@ impl<T: Clone> Dpb<T> {
     }
 
     // 8.2.5.3
-    pub fn sliding_window_marking(&self, pic: &mut PictureData, sps: &Sps) -> anyhow::Result<()> {
+    pub fn sliding_window_marking(
+        &mut self,
+        pic: &mut PictureData,
+        sps: &Sps,
+    ) -> anyhow::Result<()> {
         // If the current picture is a coded field that is the second field in
         // decoding order of a complementary reference field pair, and the first
         // field has been marked as "used for short-term reference", the current

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -531,10 +531,7 @@ impl<T: Clone> Dpb<T> {
         // picture and the complementary reference field pair are also marked as
         // "used for short-term reference".
         if let FieldRank::Second(other_field) = pic.field_rank() {
-            if matches!(
-                other_field.upgrade().map(|f| *f.borrow().reference()),
-                Some(Reference::ShortTerm)
-            ) {
+            if matches!(other_field.borrow().reference(), Reference::ShortTerm) {
                 pic.set_reference(Reference::ShortTerm, false);
                 return Ok(());
             }

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -412,14 +412,14 @@ impl<T: Clone> Dpb<T> {
 
         dpb_entry.needed_for_output = false;
         // Lookup the second field entry and flip as well.
-        if let Some(other_pic) = pic.other_field() {
+        // `find_lowest_poc_for_bumping_mut` always returns the first field, never the second.
+        if let FieldRank::First(second_field) = pic.field_rank() {
+            let second_field = second_field.upgrade();
             drop(pic);
-            if let Some(other_entry) = self
-                .entries
-                .iter_mut()
-                .find(|e| Rc::ptr_eq(&other_pic, &e.pic))
+            if let Some(second_field) =
+                second_field.and_then(|f| self.entries.iter_mut().find(|e| Rc::ptr_eq(&f, &e.pic)))
             {
-                other_entry.needed_for_output = false;
+                second_field.needed_for_output = false;
             }
         }
 

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -68,7 +68,7 @@ impl<T> DpbEntry<T> {
             // Progressive frames in the DPB are fully decoded.
             Field::Frame => true,
             // Only return the first field of fully decoded interlaced frames.
-            Field::Top | Field::Bottom => !pic.is_second_field() && pic.other_field().is_some(),
+            Field::Top | Field::Bottom => matches!(pic.field_rank(), FieldRank::First(..)),
         }
     }
 }

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -817,18 +817,18 @@ impl<T: Clone> Dpb<T> {
 
         let is_frame = matches!(pic.field, Field::Frame);
 
-        let is_second_ref_field = pic.is_second_field()
-            && matches!(
-                pic.other_field().unwrap().borrow().reference(),
-                Reference::LongTerm
-            );
+        let is_second_ref_field = match pic.field_rank() {
+            FieldRank::Second(first_field)
+                if *first_field.borrow().reference() == Reference::LongTerm =>
+            {
+                first_field.borrow_mut().long_term_frame_idx = long_term_frame_idx;
+                true
+            }
+            _ => false,
+        };
 
         pic.set_reference(Reference::LongTerm, is_frame || is_second_ref_field);
         pic.long_term_frame_idx = long_term_frame_idx;
-
-        if is_second_ref_field {
-            pic.other_field().unwrap().borrow_mut().long_term_frame_idx = long_term_frame_idx;
-        }
     }
 
     #[cfg(debug_assertions)]

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -329,19 +329,18 @@ impl<T: Clone> Dpb<T> {
 
     /// Whether the DPB has an empty slot for a new picture.
     pub fn has_empty_frame_buffer(&self) -> bool {
-        if !self.interlaced {
-            self.entries.len() < self.max_num_pics
+        let count = if !self.interlaced {
+            self.entries.len()
         } else {
-            let count = self
-                .pictures()
+            self.pictures()
                 .filter(|pic| {
                     !pic.is_second_field()
                         && (matches!(pic.field, Field::Frame) || pic.other_field().is_some())
                 })
-                .count();
+                .count()
+        };
 
-            count < self.max_num_pics
-        }
+        count < self.max_num_pics
     }
 
     /// Whether the DPB needs bumping, as described by clauses 1, 4, 5, 6 of

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -401,7 +401,8 @@ impl<T: Clone> Dpb<T> {
     /// Bump the dpb, returning a picture as per the bumping process described in C.4.5.3.
     /// Note that this picture will still be referenced by its pair, if any.
     fn bump(&mut self) -> Option<Option<T>> {
-        let dpb_entry = self.find_lowest_poc_for_bumping()?.clone();
+        let dpb_entry = self.find_lowest_poc_for_bumping()?;
+        let handle = dpb_entry.handle.clone();
         let mut pic = dpb_entry.pic.borrow_mut();
 
         debug!("Bumping picture {:#?} from the dpb", pic);
@@ -411,8 +412,7 @@ impl<T: Clone> Dpb<T> {
             other_field_rc.borrow_mut().needed_for_output = false;
         }
 
-        drop(pic);
-        Some(dpb_entry.handle)
+        Some(handle)
     }
 
     /// Drains the DPB by continuously invoking the bumping process.

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -999,9 +999,10 @@ impl<T: Clone> Dpb<T> {
 
         let num_short_term_refs = ref_pic_list_p0.len();
 
-        ref_pic_list_p0.extend(self.long_term_refs_iter());
-        // BUG what if we remove stuff here, aren't we going to invalidate `num_short_term_refs`?
-        ref_pic_list_p0.retain(|h| !h.pic.borrow().is_second_field());
+        ref_pic_list_p0.extend(
+            self.long_term_refs_iter()
+                .filter(|h| !h.pic.borrow().is_second_field()),
+        );
         Self::sort_long_term_pic_num_ascending(&mut ref_pic_list_p0[num_short_term_refs..]);
 
         #[cfg(debug_assertions)]

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -670,14 +670,15 @@ impl<T: Clone> Dpb<T> {
                 // part of a complementary field pair that includes
                 // the picture specified by picNumX, that field is
                 // marked as "unused for reference".
-                let reference_field_is_not_part_of_pic_x = if picture.other_field().is_none() {
-                    true
-                } else {
-                    // Check that the fields do not reference one another.
-                    !std::ptr::eq(picture.other_field().unwrap().as_ptr(), to_mark_as_long_ptr)
-                        && to_mark_as_long_other_field_ptr
-                            .map(|p| !std::ptr::eq(p, &(*picture)))
-                            .unwrap_or(true)
+                let reference_field_is_not_part_of_pic_x = match picture.other_field() {
+                    None => true,
+                    Some(other_field) => {
+                        // Check that the fields do not reference one another.
+                        !std::ptr::eq(other_field.as_ptr(), to_mark_as_long_ptr)
+                            && to_mark_as_long_other_field_ptr
+                                .map(|p| !std::ptr::eq(p, &(*picture)))
+                                .unwrap_or(true)
+                    }
                 };
 
                 if reference_field_is_not_part_of_pic_x {

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -622,24 +622,19 @@ impl<T: Clone> Dpb<T> {
         let to_mark_as_long_pos = self
             .find_short_term_with_pic_num_pos(pic_num_x)
             .ok_or(MmcoError::NoShortTermPic)?;
-        let to_mark_as_long = &self.entries[to_mark_as_long_pos];
-        let to_mark_as_long_ptr = to_mark_as_long.pic.as_ptr();
-        let to_mark_as_long_other_field_ptr = to_mark_as_long
-            .pic
-            .borrow()
-            .other_field()
-            .map(|f| f.as_ptr());
+        let to_mark_as_long = &self.entries[to_mark_as_long_pos].pic;
 
-        if !matches!(
-            to_mark_as_long.pic.borrow().reference(),
-            Reference::ShortTerm
-        ) {
+        if !matches!(to_mark_as_long.borrow().reference(), Reference::ShortTerm) {
             return Err(MmcoError::ExpectedMarked);
         }
 
-        if to_mark_as_long.pic.borrow().nonexisting {
+        if to_mark_as_long.borrow().nonexisting {
             return Err(MmcoError::ExpectedExisting);
         }
+
+        let to_mark_as_long_ptr = to_mark_as_long.as_ptr();
+        let to_mark_as_long_other_field_ptr =
+            to_mark_as_long.borrow().other_field().map(|f| f.as_ptr());
 
         let long_term_frame_idx = marking.long_term_frame_idx;
 
@@ -693,14 +688,13 @@ impl<T: Clone> Dpb<T> {
         }
 
         let is_frame = matches!(pic.field, Field::Frame);
-        let to_mark_as_long = &self.entries[to_mark_as_long_pos];
+        let to_mark_as_long = &self.entries[to_mark_as_long_pos].pic;
         to_mark_as_long
-            .pic
             .borrow_mut()
             .set_reference(Reference::LongTerm, is_frame);
-        to_mark_as_long.pic.borrow_mut().long_term_frame_idx = long_term_frame_idx;
+        to_mark_as_long.borrow_mut().long_term_frame_idx = long_term_frame_idx;
 
-        if let Some(other_field) = to_mark_as_long.pic.borrow().other_field() {
+        if let Some(other_field) = to_mark_as_long.borrow().other_field() {
             let mut other_field = other_field.borrow_mut();
             if matches!(other_field.reference(), Reference::LongTerm) {
                 other_field.long_term_frame_idx = long_term_frame_idx;

--- a/src/codec/h264/picture.rs
+++ b/src/codec/h264/picture.rs
@@ -8,6 +8,7 @@ use std::rc::Weak;
 
 use log::debug;
 
+use crate::codec::h264::parser::MaxLongTermFrameIdx;
 use crate::codec::h264::parser::RefPicMarking;
 use crate::codec::h264::parser::Slice;
 use crate::codec::h264::parser::SliceType;
@@ -263,6 +264,22 @@ impl PictureData {
     pub fn set_first_field_to(&mut self, other_field: &Rc<RefCell<Self>>) {
         self.other_field = Some(Rc::downgrade(other_field));
         self.is_second_field = true;
+    }
+
+    pub fn pic_num_f(&self, max_pic_num: i32) -> i32 {
+        if !matches!(self.reference(), Reference::LongTerm) {
+            self.pic_num
+        } else {
+            max_pic_num
+        }
+    }
+
+    pub fn long_term_pic_num_f(&self, max_long_term_frame_idx: MaxLongTermFrameIdx) -> u32 {
+        if matches!(self.reference(), Reference::LongTerm) {
+            self.long_term_pic_num
+        } else {
+            2 * max_long_term_frame_idx.to_value_plus1()
+        }
     }
 
     /// Split a frame into two complementary fields that reference one another.

--- a/src/codec/h264/picture.rs
+++ b/src/codec/h264/picture.rs
@@ -306,11 +306,7 @@ impl PictureData {
     /// Whether the current picture is the second field of a complementary ref pair.
     pub fn is_second_field_of_complementary_ref_pair(&self) -> bool {
         self.is_ref()
-            && self.is_second_field()
-            && self
-                .other_field()
-                .map(|f| f.borrow().is_ref())
-                .unwrap_or(false)
+            && matches!(self.field_rank(), FieldRank::Second(first_field) if first_field.borrow().is_ref())
     }
 
     /// Set this picture's first field.

--- a/src/codec/h264/picture.rs
+++ b/src/codec/h264/picture.rs
@@ -354,16 +354,17 @@ impl PictureData {
             self.frame_num, self.pic_order_cnt
         );
 
-        let pic_order_cnt;
-        if self.top_field_order_cnt < self.bottom_field_order_cnt {
+        let second_pic_order_cnt = if self.top_field_order_cnt < self.bottom_field_order_cnt {
             self.field = Field::Top;
             self.pic_order_cnt = self.top_field_order_cnt;
-            pic_order_cnt = self.bottom_field_order_cnt;
+
+            self.bottom_field_order_cnt
         } else {
             self.field = Field::Bottom;
             self.pic_order_cnt = self.bottom_field_order_cnt;
-            pic_order_cnt = self.top_field_order_cnt;
-        }
+
+            self.top_field_order_cnt
+        };
 
         let second_field = PictureData {
             top_field_order_cnt: self.top_field_order_cnt,
@@ -371,7 +372,7 @@ impl PictureData {
             frame_num: self.frame_num,
             reference: self.reference,
             nonexisting: self.nonexisting,
-            pic_order_cnt,
+            pic_order_cnt: second_pic_order_cnt,
             field: self.field.opposite(),
             ..Default::default()
         };

--- a/src/codec/h264/picture.rs
+++ b/src/codec/h264/picture.rs
@@ -79,7 +79,6 @@ pub struct PictureData {
     reference: Reference,
     pub ref_pic_list_modification_flag_l0: i32,
     pub abs_diff_pic_num_minus1: i32,
-    pub needed_for_output: bool,
 
     // Does memory management op 5 needs to be executed after this
     // picture has finished decoding?
@@ -365,7 +364,6 @@ impl std::fmt::Debug for PictureData {
                 &self.ref_pic_list_modification_flag_l0,
             )
             .field("abs_diff_pic_num_minus1", &self.abs_diff_pic_num_minus1)
-            .field("needed_for_output", &self.needed_for_output)
             .field("has_mmco_5", &self.has_mmco_5)
             .field("nonexisting", &self.nonexisting)
             .field("field", &self.field)

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -577,22 +577,6 @@ where
         }
     }
 
-    fn pic_num_f(pic: &PictureData, max_pic_num: i32) -> i32 {
-        if !matches!(pic.reference(), Reference::LongTerm) {
-            pic.pic_num
-        } else {
-            max_pic_num
-        }
-    }
-
-    fn long_term_pic_num_f(pic: &PictureData, max_long_term_frame_idx: MaxLongTermFrameIdx) -> u32 {
-        if matches!(pic.reference(), Reference::LongTerm) {
-            pic.long_term_pic_num
-        } else {
-            2 * max_long_term_frame_idx.to_value_plus1()
-        }
-    }
-
     // 8.2.4.3.1 Modification process of reference picture lists for short-term
     // reference pictures
     #[allow(clippy::too_many_arguments)]
@@ -653,7 +637,7 @@ where
 
             let target = &ref_pic_list_x[cidx].pic;
 
-            if Self::pic_num_f(&target.borrow(), max_pic_num) != pic_num_lx {
+            if target.borrow().pic_num_f(max_pic_num) != pic_num_lx {
                 ref_pic_list_x[nidx] = ref_pic_list_x[cidx];
                 nidx += 1;
             }
@@ -696,9 +680,7 @@ where
             }
 
             let target = &ref_pic_list_x[cidx].pic;
-            if Self::long_term_pic_num_f(&target.borrow(), max_long_term_frame_idx)
-                != long_term_pic_num
-            {
+            if target.borrow().long_term_pic_num_f(max_long_term_frame_idx) != long_term_pic_num {
                 ref_pic_list_x[nidx] = ref_pic_list_x[cidx];
                 nidx += 1;
             }

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -1082,11 +1082,8 @@ where
         let sps = Rc::clone(&pps.sps);
         let max_frame_num = sps.max_frame_num();
 
-        let mut pic = PictureData::new_from_slice(slice, &sps, timestamp);
+        let mut pic = PictureData::new_from_slice(slice, &sps, timestamp, first_field);
         self.codec.compute_pic_order_count(&mut pic, &sps)?;
-        if let Some(first_field) = first_field {
-            pic.set_first_field_to(first_field);
-        }
 
         if matches!(pic.is_idr, IsIdr::Yes { .. }) {
             // C.4.5.3 "Bumping process"
@@ -1165,7 +1162,6 @@ where
         }
 
         let first_field = self.codec.find_first_field(&slice.header)?;
-
         let pic = self.init_current_pic(slice, first_field.as_ref().map(|f| &f.0), timestamp)?;
         let ref_pic_lists = self.codec.dpb.build_ref_pic_lists(&pic);
 

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -982,16 +982,15 @@ where
                 // Split the Frame into two complementary fields so reference
                 // marking is easier. This is inspired by the GStreamer implementation.
                 let (first_field, second_field) = PictureData::split_frame(pic);
-                let second_field_handle = handle.clone();
 
                 self.codec.dpb.add_picture(
                     first_field,
-                    Some(handle),
+                    Some(handle.clone()),
                     &mut self.codec.last_field,
                 )?;
                 self.codec.dpb.add_picture(
                     second_field,
-                    Some(second_field_handle),
+                    Some(handle),
                     &mut self.codec.last_field,
                 )?;
             } else {

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -502,7 +502,6 @@ where
     fn drain(&mut self) -> impl Iterator<Item = H> {
         let pics = self.dpb.drain();
 
-        self.dpb.clear();
         self.last_field = None;
 
         pics.into_iter().flatten()
@@ -951,8 +950,6 @@ where
 
         self.codec.prev_pic_info.fill(&pic);
 
-        self.codec.dpb.remove_unused();
-
         if pic.has_mmco_5 {
             // C.4.5.3 "Bumping process"
             // The bumping process is invoked in the following cases:
@@ -1044,7 +1041,6 @@ where
 
             self.codec.dpb.sliding_window_marking(&mut pic, sps)?;
 
-            self.codec.dpb.remove_unused();
             self.ready_queue.extend(self.codec.bump_as_needed(&pic));
 
             if self.codec.dpb.interlaced() {

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -30,6 +30,7 @@ use crate::codec::h264::parser::SliceHeader;
 use crate::codec::h264::parser::SliceType;
 use crate::codec::h264::parser::Sps;
 use crate::codec::h264::picture::Field;
+use crate::codec::h264::picture::FieldRank;
 use crate::codec::h264::picture::IsIdr;
 use crate::codec::h264::picture::PictureData;
 use crate::codec::h264::picture::RcPictureData;
@@ -914,12 +915,7 @@ where
                     // Cache the field, wait for its pair.
                     self.codec.last_field = Some((pic.into_rc(), handle));
                 }
-                Some((field_pic, field_handle))
-                    if pic.is_second_field()
-                        && pic
-                            .other_field()
-                            .map(|f| Rc::ptr_eq(&f, &field_pic))
-                            .unwrap_or(false) =>
+                Some((field_pic, field_handle)) if matches!(pic.field_rank(), FieldRank::Second(first_field) if Rc::ptr_eq(first_field, &field_pic)) =>
                 {
                     self.ready_queue.push(field_handle);
                 }


### PR DESCRIPTION
A few simplifications/improvements for H.264. A lot of commits, but they should be small and hopefully easy to review.

The long-term goal here is:

* Remove uses of unwraps() by using sounder data types, e.g. enums when it is relevant,
* Remove `borrow_mut` access of the `RefCell` in the DPB, in the hope to eventually get rid of it (we already had crashes due to the borrow rules being violated at runtime),
* Make the code easier to understand by using more self-evident types and idiomatic Rust code.

None of these goals are entirely completed by this PR, but it hopefully gets us closer and can serve as inspiration for doing similar for in H.265.