### PR TITLE
codec/av1: Fix invalid decoder_model syntax size

### DIFF
--- a/src/codec/av1/synthesizer.rs
+++ b/src/codec/av1/synthesizer.rs
@@ -582,8 +582,8 @@ where
 
         self.f(5, dm.buffer_delay_length_minus_1)?;
         self.f(32, dm.num_units_in_decoding_tick)?;
-        self.f(32, dm.buffer_removal_time_length_minus_1)?;
-        self.f(32, dm.frame_presentation_time_length_minus_1)?;
+        self.f(5, dm.buffer_removal_time_length_minus_1)?;
+        self.f(5, dm.frame_presentation_time_length_minus_1)?;
 
         Ok(())
     }


### PR DESCRIPTION
This commit fixes the invalid invalid buffer_removal_time_length_minus_1 and frame_presentation_time_length_minus_1 syntax field size.

This fixes issue #79.