### PR TITLE
Fixes/improvements for the H.264 parser

### DIFF
--- a/src/codec/h264/nalu_reader.rs
+++ b/src/codec/h264/nalu_reader.rs
@@ -20,7 +20,7 @@ pub(crate) struct NaluReader<'a> {
     /// Number of bits remaining in `curr_byte`
     num_remaining_bits_in_curr_byte: usize,
     /// Used in epb detection.
-    prev_two_bytes: u32,
+    prev_two_bytes: u16,
     /// Number of epbs (i.e. 0x000003) we found.
     num_epb: usize,
 }
@@ -208,7 +208,7 @@ impl<'a> NaluReader<'a> {
     fn update_curr_byte(&mut self) -> Result<(), GetByteError> {
         let mut byte = self.get_byte()?;
 
-        if (self.prev_two_bytes & 0xffff) == 0 && byte == 0x03 {
+        if self.prev_two_bytes == 0 && byte == 0x03 {
             // We found an epb
             self.num_epb += 1;
             // Read another byte
@@ -218,7 +218,7 @@ impl<'a> NaluReader<'a> {
         }
 
         self.num_remaining_bits_in_curr_byte = 8;
-        self.prev_two_bytes = ((self.prev_two_bytes & 0xff) << 8) | u32::from(byte);
+        self.prev_two_bytes = (self.prev_two_bytes << 8) | u16::from(byte);
 
         self.curr_byte = u32::from(byte);
         Ok(())

--- a/src/codec/h264/nalu_reader.rs
+++ b/src/codec/h264/nalu_reader.rs
@@ -132,24 +132,20 @@ impl<'a> NaluReader<'a> {
 
     pub fn read_ue<U: TryFrom<u32>>(&mut self) -> anyhow::Result<U> {
         let mut num_bits = 0;
-        let mut bit = self.read_bits::<u32>(1)?;
 
-        while bit == 0 {
+        while self.read_bits::<u32>(1)? == 0 {
             num_bits += 1;
-            bit = self.read_bits(1)?;
         }
 
         if num_bits > 31 {
-            return Err(anyhow!("Invalid stream"));
+            return Err(anyhow!("invalid stream"));
         }
 
         let mut value = (1 << num_bits) - 1;
-        let rest;
 
         // Check for overflow
         if num_bits == 31 {
-            rest = self.read_bits::<u32>(num_bits)?;
-            if rest == 0 {
+            if self.read_bits::<u32>(num_bits)? == 0 {
                 return U::try_from(value).map_err(|_| anyhow!("Conversion error"));
             } else {
                 return Err(anyhow!("Invalid stream"));

--- a/src/codec/h264/nalu_reader.rs
+++ b/src/codec/h264/nalu_reader.rs
@@ -16,7 +16,7 @@ pub(crate) struct NaluReader<'a> {
     data: Cursor<&'a [u8]>,
     /// Contents of the current byte. First unread bit starting at position 8 -
     /// num_remaining_bits_in_curr_bytes.
-    curr_byte: u32,
+    curr_byte: u8,
     /// Number of bits remaining in `curr_byte`
     num_remaining_bits_in_curr_byte: usize,
     /// Used in epb detection.
@@ -69,15 +69,15 @@ impl<'a> NaluReader<'a> {
         }
 
         let mut bits_left = num_bits;
-        let mut out = 0;
+        let mut out = 0u32;
 
         while self.num_remaining_bits_in_curr_byte < bits_left {
-            out |= self.curr_byte << (bits_left - self.num_remaining_bits_in_curr_byte);
+            out |= (self.curr_byte as u32) << (bits_left - self.num_remaining_bits_in_curr_byte);
             bits_left -= self.num_remaining_bits_in_curr_byte;
             self.update_curr_byte()?;
         }
 
-        out |= self.curr_byte >> (self.num_remaining_bits_in_curr_byte - bits_left);
+        out |= (self.curr_byte >> (self.num_remaining_bits_in_curr_byte - bits_left)) as u32;
         out &= (1 << num_bits) - 1;
         self.num_remaining_bits_in_curr_byte -= bits_left;
 
@@ -220,7 +220,7 @@ impl<'a> NaluReader<'a> {
         self.num_remaining_bits_in_curr_byte = 8;
         self.prev_two_bytes = (self.prev_two_bytes << 8) | u16::from(byte);
 
-        self.curr_byte = u32::from(byte);
+        self.curr_byte = byte;
         Ok(())
     }
 }

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -916,12 +916,6 @@ impl SpsBuilder {
         self
     }
 
-    pub fn resolution_in_mbs(mut self, width: u32, height: u32) -> Self {
-        self.0.pic_width_in_mbs_minus1 = width - 1;
-        self.0.pic_height_in_map_units_minus1 = height - 1;
-        self
-    }
-
     pub fn frame_crop_offsets(mut self, top: u32, bottom: u32, left: u32, right: u32) -> Self {
         self.0.frame_cropping_flag = true;
         self.0.frame_crop_top_offset = top;
@@ -952,7 +946,8 @@ impl SpsBuilder {
         let mb_width = (width + MB_SIZE - 1) / MB_SIZE;
         let mb_height = (height + MB_SIZE - 1) / MB_SIZE;
 
-        self = self.resolution_in_mbs(mb_width, mb_height);
+        self.0.pic_width_in_mbs_minus1 = mb_width - 1;
+        self.0.pic_height_in_map_units_minus1 = mb_height - 1;
 
         let compressed_width = mb_width * MB_SIZE;
         let compressed_height = mb_height * MB_SIZE;

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -729,6 +729,35 @@ impl Sps {
             * (2 - u32::from(self.frame_mbs_only_flag))
     }
 
+    /// Returns `SubWidthC` and `SubHeightC`.
+    ///
+    /// See table 6-1 in the specification.
+    fn sub_width_height_c(&self) -> (u32, u32) {
+        match (self.chroma_format_idc, self.separate_colour_plane_flag) {
+            (1, false) => (2, 2),
+            (2, false) => (2, 1),
+            (3, false) => (1, 1),
+            // undefined.
+            _ => (1, 1),
+        }
+    }
+
+    /// Returns `CropUnitX` and `CropUnitY`.
+    ///
+    /// See 7-19 through 7-22 in the specification.
+    fn crop_unit_x_y(&self) -> (u32, u32) {
+        match self.chroma_array_type {
+            0 => (1, 2 - u32::from(self.frame_mbs_only_flag)),
+            _ => {
+                let (sub_width_c, sub_height_c) = self.sub_width_height_c();
+                (
+                    sub_width_c,
+                    sub_height_c * (2 - u32::from(self.frame_mbs_only_flag)),
+                )
+            }
+        }
+    }
+
     /// Same as MaxFrameNum. See 7-10 in the specification.
     pub fn max_frame_num(&self) -> u32 {
         1 << (self.log2_max_frame_num_minus4 + 4)
@@ -745,17 +774,7 @@ impl Sps {
             };
         }
 
-        let crop_unit_x;
-        let crop_unit_y;
-        if self.chroma_array_type == 0 {
-            crop_unit_x = 1;
-            crop_unit_y = if self.frame_mbs_only_flag { 1 } else { 2 };
-        } else {
-            let sub_width_c = if self.chroma_format_idc > 2 { 1 } else { 2 };
-            let sub_height_c = if self.chroma_format_idc > 1 { 1 } else { 2 };
-            crop_unit_x = sub_width_c;
-            crop_unit_y = sub_height_c * (if self.frame_mbs_only_flag { 1 } else { 2 });
-        }
+        let (crop_unit_x, crop_unit_y) = self.crop_unit_x_y();
 
         let crop_left = crop_unit_x * self.frame_crop_left_offset;
         let crop_right = crop_unit_x * self.frame_crop_right_offset;
@@ -2028,13 +2047,7 @@ impl Parser {
         let mut height = sps.height();
 
         if sps.frame_cropping_flag {
-            // Table 6-1 in the spec.
-            let sub_width_c = [1, 2, 2, 1];
-            let sub_height_c = [1, 2, 1, 1];
-
-            let crop_unit_x = sub_width_c[usize::from(sps.chroma_format_idc)];
-            let crop_unit_y = sub_height_c[usize::from(sps.chroma_format_idc)]
-                * (2 - u32::from(sps.frame_mbs_only_flag));
+            let (crop_unit_x, crop_unit_y) = sps.crop_unit_x_y();
 
             width = width
                 .checked_sub(

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -691,8 +691,6 @@ pub struct Sps {
     pub frame_crop_bottom_offset: u32,
 
     // Calculated
-    /// Same as ChromaArrayType. See the definition in the specification.
-    pub chroma_array_type: u8,
     /// Same as ExpectedDeltaPerPicOrderCntCycle, see 7-12 in the specification.
     pub expected_delta_per_pic_order_cnt_cycle: i32,
 
@@ -717,6 +715,14 @@ impl Sps {
             * (2 - u32::from(self.frame_mbs_only_flag))
     }
 
+    /// Returns `ChromaArrayType`, as computed in the specification.
+    pub fn chroma_array_type(&self) -> u8 {
+        match self.separate_colour_plane_flag {
+            false => self.chroma_format_idc,
+            true => 0,
+        }
+    }
+
     /// Returns `SubWidthC` and `SubHeightC`.
     ///
     /// See table 6-1 in the specification.
@@ -734,7 +740,7 @@ impl Sps {
     ///
     /// See 7-19 through 7-22 in the specification.
     fn crop_unit_x_y(&self) -> (u32, u32) {
-        match self.chroma_array_type {
+        match self.chroma_array_type() {
             0 => (1, 2 - u32::from(self.frame_mbs_only_flag)),
             _ => {
                 let (sub_width_c, sub_height_c) = self.sub_width_height_c();
@@ -898,7 +904,6 @@ impl Default for Sps {
             frame_crop_right_offset: Default::default(),
             frame_crop_top_offset: Default::default(),
             frame_crop_bottom_offset: Default::default(),
-            chroma_array_type: Default::default(),
             expected_delta_per_pic_order_cnt_cycle: Default::default(),
             vui_parameters_present_flag: Default::default(),
             vui_parameters: Default::default(),
@@ -1972,12 +1977,6 @@ impl Parser {
             Parser::fill_scaling_list_flat(&mut sps.scaling_lists_4x4, &mut sps.scaling_lists_8x8);
         }
 
-        if sps.separate_colour_plane_flag {
-            sps.chroma_array_type = 0;
-        } else {
-            sps.chroma_array_type = sps.chroma_format_idc;
-        }
-
         sps.log2_max_frame_num_minus4 = r.read_ue_max(12)?;
 
         sps.pic_order_cnt_type = r.read_ue_max(2)?;
@@ -2251,7 +2250,7 @@ impl Parser {
             }
         }
 
-        if sps.chroma_array_type != 0 {
+        if sps.chroma_array_type() != 0 {
             pt.chroma_log2_weight_denom = r.read_ue_max(7)?;
             let default_chroma_weight = 1 << pt.chroma_log2_weight_denom;
 
@@ -2280,7 +2279,7 @@ impl Parser {
                 pt.luma_offset_l0[usize::from(i)] = r.read_se_bounded(-128, 127)?;
             }
 
-            if sps.chroma_array_type != 0 {
+            if sps.chroma_array_type() != 0 {
                 let chroma_weight_l0_flag = r.read_bit()?;
                 if chroma_weight_l0_flag {
                     for j in 0..2 {
@@ -2300,7 +2299,7 @@ impl Parser {
                     pt.luma_offset_l1[usize::from(i)] = r.read_se_bounded(-128, 127)?;
                 }
 
-                if sps.chroma_array_type != 0 {
+                if sps.chroma_array_type() != 0 {
                     let chroma_weight_l1_flag = r.read_bit()?;
                     if chroma_weight_l1_flag {
                         for j in 0..2 {
@@ -2702,7 +2701,7 @@ mod tests {
             assert_eq!(sps.frame_crop_right_offset, 0);
             assert_eq!(sps.frame_crop_top_offset, 0);
             assert_eq!(sps.frame_crop_bottom_offset, 0);
-            assert_eq!(sps.chroma_array_type, 1);
+            assert_eq!(sps.chroma_array_type(), 1);
             assert_eq!(sps.max_frame_num(), 32);
             assert_eq!(sps.width(), 320);
             assert_eq!(sps.height(), 240);

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -647,7 +647,7 @@ pub struct Sps {
 
     /// Plus 1 specifies the width of each decoded picture in units of
     /// macroblocks.
-    pub pic_width_in_mbs_minus1: u32,
+    pub pic_width_in_mbs_minus1: u8,
     /// Plus 1 specifies the height in slice group map units of a decoded frame
     /// or field.
     pub pic_height_in_map_units_minus1: u32,
@@ -717,7 +717,7 @@ impl Sps {
     ///
     /// See 7-13 through 7-17 in the specification.
     pub fn width(&self) -> u32 {
-        (self.pic_width_in_mbs_minus1 + 1) * 16
+        (self.pic_width_in_mbs_minus1 as u32 + 1) * 16
     }
 
     /// Returns the coded height of the stream.

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -650,7 +650,7 @@ pub struct Sps {
     pub pic_width_in_mbs_minus1: u8,
     /// Plus 1 specifies the height in slice group map units of a decoded frame
     /// or field.
-    pub pic_height_in_map_units_minus1: u32,
+    pub pic_height_in_map_units_minus1: u8,
 
     /// If true,  specifies that every coded picture of the coded video sequence
     /// is a coded frame containing only frame macroblocks, else specifies that
@@ -724,7 +724,9 @@ impl Sps {
     ///
     /// See 7-13 through 7-17 in the specification.
     pub fn height(&self) -> u32 {
-        (self.pic_height_in_map_units_minus1 + 1) * 16 * (2 - u32::from(self.frame_mbs_only_flag))
+        (self.pic_height_in_map_units_minus1 as u32 + 1)
+            * 16
+            * (2 - u32::from(self.frame_mbs_only_flag))
     }
 
     /// Same as MaxFrameNum. See 7-10 in the specification.
@@ -954,8 +956,8 @@ impl SpsBuilder {
         let mb_width = (width + MB_SIZE - 1) / MB_SIZE;
         let mb_height = (height + MB_SIZE - 1) / MB_SIZE;
 
-        self.0.pic_width_in_mbs_minus1 = mb_width - 1;
-        self.0.pic_height_in_map_units_minus1 = mb_height - 1;
+        self.0.pic_width_in_mbs_minus1 = (mb_width - 1) as u8;
+        self.0.pic_height_in_map_units_minus1 = (mb_height - 1) as u8;
 
         let compressed_width = mb_width * MB_SIZE;
         let compressed_height = mb_height * MB_SIZE;

--- a/src/codec/h264/parser.rs
+++ b/src/codec/h264/parser.rs
@@ -693,10 +693,6 @@ pub struct Sps {
     // Calculated
     /// Same as ChromaArrayType. See the definition in the specification.
     pub chroma_array_type: u8,
-    /// See 7-13 through 7-17 in the specification.
-    pub width: u32,
-    /// See 7-13 through 7-17 in the specification.
-    pub height: u32,
     /// See the documentation for frame_crop_{left|right|top|bottom}_offset in
     /// the specification
     pub crop_rect_width: u32,
@@ -717,6 +713,20 @@ pub struct Sps {
 }
 
 impl Sps {
+    /// Returns the coded width of the stream.
+    ///
+    /// See 7-13 through 7-17 in the specification.
+    pub fn width(&self) -> u32 {
+        (self.pic_width_in_mbs_minus1 + 1) * 16
+    }
+
+    /// Returns the coded height of the stream.
+    ///
+    /// See 7-13 through 7-17 in the specification.
+    pub fn height(&self) -> u32 {
+        (self.pic_height_in_map_units_minus1 + 1) * 16 * (2 - u32::from(self.frame_mbs_only_flag))
+    }
+
     /// Same as MaxFrameNum. See 7-10 in the specification.
     pub fn max_frame_num(&self) -> u32 {
         1 << (self.log2_max_frame_num_minus4 + 4)
@@ -727,8 +737,8 @@ impl Sps {
             return Rect {
                 min: Point { x: 0, y: 0 },
                 max: Point {
-                    x: self.width,
-                    y: self.height,
+                    x: self.width(),
+                    y: self.height(),
                 },
             };
         }
@@ -756,8 +766,8 @@ impl Sps {
                 y: crop_top,
             },
             max: Point {
-                x: self.width - crop_left - crop_right,
-                y: self.height - crop_top - crop_bottom,
+                x: self.width() - crop_left - crop_right,
+                y: self.height() - crop_top - crop_bottom,
             },
         }
     }
@@ -799,8 +809,8 @@ impl Sps {
             Level::L6_2 => 696320,
         };
 
-        let width_mb = self.width / 16;
-        let height_mb = self.height / 16;
+        let width_mb = self.width() / 16;
+        let height_mb = self.height() / 16;
 
         let max_dpb_frames =
             std::cmp::min(max_dpb_mbs / (width_mb * height_mb), DPB_MAX_SIZE as u32) as usize;
@@ -880,8 +890,6 @@ impl Default for Sps {
             frame_crop_top_offset: Default::default(),
             frame_crop_bottom_offset: Default::default(),
             chroma_array_type: Default::default(),
-            width: Default::default(),
-            height: Default::default(),
             crop_rect_width: Default::default(),
             crop_rect_height: Default::default(),
             crop_rect_x: Default::default(),
@@ -2014,13 +2022,8 @@ impl Parser {
             Parser::parse_vui(&mut r, &mut sps)?;
         }
 
-        let mut width = (sps.pic_width_in_mbs_minus1 + 1) * 16;
-        let mut height = (sps.pic_height_in_map_units_minus1 + 1)
-            * 16
-            * (2 - u32::from(sps.frame_mbs_only_flag));
-
-        sps.width = width;
-        sps.height = height;
+        let mut width = sps.width();
+        let mut height = sps.height();
 
         if sps.frame_cropping_flag {
             // Table 6-1 in the spec.
@@ -2709,8 +2712,8 @@ mod tests {
             assert_eq!(sps.frame_crop_bottom_offset, 0);
             assert_eq!(sps.chroma_array_type, 1);
             assert_eq!(sps.max_frame_num(), 32);
-            assert_eq!(sps.width, 320);
-            assert_eq!(sps.height, 240);
+            assert_eq!(sps.width(), 320);
+            assert_eq!(sps.height(), 240);
             assert_eq!(sps.crop_rect_width, 0);
             assert_eq!(sps.crop_rect_height, 0);
             assert_eq!(sps.crop_rect_x, 0);

--- a/src/codec/h264/picture.rs
+++ b/src/codec/h264/picture.rs
@@ -214,9 +214,7 @@ impl PictureData {
             ),
         };
 
-        let width = sps.width;
-        let height = sps.height;
-        let coded_resolution = Resolution { width, height };
+        let coded_resolution = Resolution::from((sps.width(), sps.height()));
 
         let visible_rect = sps.visible_rectangle();
 

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -155,7 +155,7 @@ struct NegotiationInfo {
 impl From<&Sps> for NegotiationInfo {
     fn from(sps: &Sps) -> Self {
         NegotiationInfo {
-            coded_resolution: Resolution::from((sps.width, sps.height)),
+            coded_resolution: Resolution::from((sps.width(), sps.height())),
             profile_idc: sps.profile_idc,
             bit_depth_luma_minus8: sps.bit_depth_luma_minus8,
             bit_depth_chroma_minus8: sps.bit_depth_chroma_minus8,
@@ -886,10 +886,7 @@ where
     fn apply_sps(&mut self, sps: &Sps) {
         self.codec.apply_sps(sps);
 
-        self.coded_resolution = Resolution {
-            width: sps.width,
-            height: sps.height,
-        };
+        self.coded_resolution = Resolution::from((sps.width(), sps.height()));
     }
 
     fn drain(&mut self) -> anyhow::Result<()> {

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -101,7 +101,7 @@ impl VaStreamInfo for &Rc<Sps> {
     }
 
     fn coded_size(&self) -> (u32, u32) {
-        (self.width, self.height)
+        (self.width(), self.height())
     }
 
     fn visible_rect(&self) -> ((u32, u32), (u32, u32)) {

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -270,7 +270,8 @@ fn build_pic_param<M: SurfaceMemoryDescriptor>(
         sps.delta_pic_order_always_zero_flag as u32,
     );
     let interlaced = !sps.frame_mbs_only_flag as u32;
-    let picture_height_in_mbs_minus1 = ((sps.pic_height_in_map_units_minus1 + 1) << interlaced) - 1;
+    let picture_height_in_mbs_minus1 =
+        ((sps.pic_height_in_map_units_minus1 as u16 + 1) << interlaced) - 1;
 
     let pic_fields = libva::H264PicFields::new(
         pps.entropy_coding_mode_flag as u32,
@@ -297,7 +298,7 @@ fn build_pic_param<M: SurfaceMemoryDescriptor>(
         curr_pic,
         va_refs,
         u16::from(sps.pic_width_in_mbs_minus1),
-        u16::try_from(picture_height_in_mbs_minus1)?,
+        picture_height_in_mbs_minus1,
         sps.bit_depth_luma_minus8,
         sps.bit_depth_chroma_minus8,
         u8::try_from(sps.max_num_ref_frames)?,

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -392,7 +392,7 @@ fn build_slice_param<M: SurfaceMemoryDescriptor>(
             luma_offset_l0[i] = i16::from(pwt.luma_offset_l0[i]);
         }
 
-        chroma_weight_l0_flag = sps.chroma_array_type != 0;
+        chroma_weight_l0_flag = sps.chroma_array_type() != 0;
         if chroma_weight_l0_flag {
             for i in 0..=hdr.num_ref_idx_l0_active_minus1 as usize {
                 for j in 0..2 {
@@ -413,7 +413,7 @@ fn build_slice_param<M: SurfaceMemoryDescriptor>(
             &pwt.luma_offset_l1[..(hdr.num_ref_idx_l1_active_minus1 as usize + 1)],
         );
 
-        chroma_weight_l1_flag = sps.chroma_array_type != 0;
+        chroma_weight_l1_flag = sps.chroma_array_type() != 0;
         if chroma_weight_l1_flag {
             for i in 0..=hdr.num_ref_idx_l1_active_minus1 as usize {
                 for j in 0..2 {

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -296,7 +296,7 @@ fn build_pic_param<M: SurfaceMemoryDescriptor>(
     let pic_param = PictureParameterBufferH264::new(
         curr_pic,
         va_refs,
-        u16::try_from(sps.pic_width_in_mbs_minus1)?,
+        u16::from(sps.pic_width_in_mbs_minus1),
         u16::try_from(picture_height_in_mbs_minus1)?,
         sps.bit_depth_luma_minus8,
         sps.bit_depth_chroma_minus8,

--- a/src/encoder/stateless/h264/predictor.rs
+++ b/src/encoder/stateless/h264/predictor.rs
@@ -173,8 +173,8 @@ impl<Picture, Reference>
             self.delegate.update_params_sets = false;
         }
 
-        let num_macroblocks =
-            ((sps.pic_width_in_mbs_minus1 + 1) * (sps.pic_height_in_map_units_minus1 + 1)) as usize;
+        let num_macroblocks = (sps.pic_width_in_mbs_minus1 as usize + 1)
+            * (sps.pic_height_in_map_units_minus1 as usize + 1);
 
         let request = BackendRequest {
             sps,
@@ -245,8 +245,8 @@ impl<Picture, Reference>
             self.delegate.update_params_sets = false;
         }
 
-        let num_macroblocks =
-            ((sps.pic_width_in_mbs_minus1 + 1) * (sps.pic_height_in_map_units_minus1 + 1)) as usize;
+        let num_macroblocks = (sps.pic_width_in_mbs_minus1 as usize + 1)
+            * (sps.pic_height_in_map_units_minus1 as usize + 1);
 
         let request = BackendRequest {
             sps,

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -585,7 +585,7 @@ pub(super) mod tests {
             .seq_parameter_set_id(0)
             .profile_idc(Profile::Main)
             .level_idc(Level::L4)
-            .resolution_in_mbs(WIDTH / 16, HEIGHT / 16)
+            .resolution(WIDTH, HEIGHT)
             .chroma_format_idc(3)
             .frame_mbs_only_flag(true)
             .direct_8x8_inference_flag(true)

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -164,7 +164,7 @@ where
                 bits_per_second,
                 sps.max_num_ref_frames,
                 sps.pic_width_in_mbs_minus1 as u16 + 1,
-                (sps.pic_height_in_map_units_minus1 + 1) as u16,
+                sps.pic_height_in_map_units_minus1 as u16 + 1,
                 &seq_fields,
                 sps.bit_depth_luma_minus8,
                 sps.bit_depth_chroma_minus8,

--- a/src/encoder/stateless/h264/vaapi.rs
+++ b/src/encoder/stateless/h264/vaapi.rs
@@ -163,7 +163,7 @@ where
                 ip_period,
                 bits_per_second,
                 sps.max_num_ref_frames,
-                (sps.pic_width_in_mbs_minus1 + 1) as u16,
+                sps.pic_width_in_mbs_minus1 as u16 + 1,
                 (sps.pic_height_in_map_units_minus1 + 1) as u16,
                 &seq_fields,
                 sps.bit_depth_luma_minus8,


### PR DESCRIPTION
A set of small changes that restrict the data types and valid ranges of some SPS parameters to make sure we don't get runtime panics due to overflows when processing invalid data.

Some of these problems have been revealed by fuzzing, some others are just drive-by improvements, notably those that move pre-computed values into methods to remove the possibility of inconsistencies and better align with the spec.