### PR TITLE
decoder/stateless: let the backends decide which resources they need

### DIFF
--- a/src/codec/h265/picture.rs
+++ b/src/codec/h265/picture.rs
@@ -53,7 +53,6 @@ impl PictureData {
         first_picture_after_eos: bool,
         prev_tid0_pic: Option<&PictureData>,
         max_pic_order_cnt_lsb: i32,
-        _timestamp: u64,
     ) -> Self {
         let hdr = &slice.header;
         let nalu_type = slice.nalu.header.type_;

--- a/src/decoder/stateless.rs
+++ b/src/decoder/stateless.rs
@@ -45,6 +45,8 @@ use crate::Resolution;
 pub enum StatelessBackendError {
     #[error("not enough resources to proceed with the operation now")]
     OutOfResources,
+    #[error("no frame pool can satisfy the requested frame resolution {0:?}")]
+    NoFramePool(Resolution),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/src/decoder/stateless/av1/dummy.rs
+++ b/src/decoder/stateless/av1/dummy.rs
@@ -28,12 +28,20 @@ impl StatelessAV1DecoderBackend for Backend {
 
     fn new_picture(
         &mut self,
-        _: &crate::codec::av1::parser::SequenceHeaderObu,
         _: &crate::codec::av1::parser::FrameHeaderObu,
         _: u64,
-        _: &[Option<Self::Handle>; crate::codec::av1::parser::NUM_REF_FRAMES],
         _: Option<u32>,
     ) -> crate::decoder::stateless::StatelessBackendResult<Self::Picture> {
+        Ok(())
+    }
+
+    fn begin_picture(
+        &mut self,
+        _: &mut Self::Picture,
+        _: &crate::codec::av1::parser::SequenceHeaderObu,
+        _: &crate::codec::av1::parser::FrameHeaderObu,
+        _: &[Option<Self::Handle>; crate::codec::av1::parser::NUM_REF_FRAMES],
+    ) -> crate::decoder::stateless::StatelessBackendResult<()> {
         Ok(())
     }
 

--- a/src/decoder/stateless/av1/dummy.rs
+++ b/src/decoder/stateless/av1/dummy.rs
@@ -31,7 +31,7 @@ impl StatelessAV1DecoderBackend for Backend {
         _: &crate::codec::av1::parser::FrameHeaderObu,
         _: u64,
         _: Option<u32>,
-    ) -> crate::decoder::stateless::StatelessBackendResult<Self::Picture> {
+    ) -> crate::decoder::stateless::NewPictureResult<Self::Picture> {
         Ok(())
     }
 

--- a/src/decoder/stateless/av1/vaapi.rs
+++ b/src/decoder/stateless/av1/vaapi.rs
@@ -539,9 +539,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessAV1DecoderBackend for VaapiB
                 };
 
                 self.pool(layer)
-                    .ok_or(StatelessBackendError::Other(anyhow!(
-                        "No pool available for this layer"
-                    )))?
+                    .ok_or(StatelessBackendError::NoFramePool(layer))?
             }
             None => self.highest_pool(),
         };

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -84,11 +84,7 @@ pub trait StatelessH264DecoderBackend:
     fn new_sequence(&mut self, sps: &Rc<Sps>) -> StatelessBackendResult<()>;
 
     /// Called when the decoder determines that a frame or field was found.
-    fn new_picture(
-        &mut self,
-        picture: &PictureData,
-        timestamp: u64,
-    ) -> StatelessBackendResult<Self::Picture>;
+    fn new_picture(&mut self, timestamp: u64) -> StatelessBackendResult<Self::Picture>;
 
     /// Called when the decoder determines that a second field was found.
     /// Indicates that the underlying BackendHandle is to be shared between the
@@ -96,7 +92,6 @@ pub trait StatelessH264DecoderBackend:
     /// resource and can thus be presented together as a single frame.
     fn new_field_picture(
         &mut self,
-        picture: &PictureData,
         timestamp: u64,
         first_field: &Self::Handle,
     ) -> StatelessBackendResult<Self::Picture>;
@@ -1154,10 +1149,9 @@ where
         debug!("Decode picture POC {:?}", pic.pic_order_cnt);
 
         let mut backend_pic = if let Some(first_field) = first_field {
-            self.backend
-                .new_field_picture(&pic, timestamp, &first_field.1)?
+            self.backend.new_field_picture(timestamp, &first_field.1)?
         } else {
-            self.backend.new_picture(&pic, timestamp)?
+            self.backend.new_picture(timestamp)?
         };
 
         self.backend.start_picture(

--- a/src/decoder/stateless/h264/dummy.rs
+++ b/src/decoder/stateless/h264/dummy.rs
@@ -41,12 +41,7 @@ impl StatelessH264DecoderBackend for Backend {
         Ok(())
     }
 
-    fn new_field_picture(
-        &mut self,
-        _: &PictureData,
-        _: u64,
-        _: &Self::Handle,
-    ) -> StatelessBackendResult<()> {
+    fn new_field_picture(&mut self, _: u64, _: &Self::Handle) -> StatelessBackendResult<()> {
         Ok(())
     }
 
@@ -68,7 +63,7 @@ impl StatelessH264DecoderBackend for Backend {
         })
     }
 
-    fn new_picture(&mut self, _: &PictureData, _: u64) -> StatelessBackendResult<()> {
+    fn new_picture(&mut self, _: u64) -> StatelessBackendResult<()> {
         Ok(())
     }
 }

--- a/src/decoder/stateless/h264/dummy.rs
+++ b/src/decoder/stateless/h264/dummy.rs
@@ -19,6 +19,7 @@ use crate::codec::h264::parser::Sps;
 use crate::codec::h264::picture::PictureData;
 use crate::decoder::stateless::h264::StatelessH264DecoderBackend;
 use crate::decoder::stateless::h264::H264;
+use crate::decoder::stateless::NewPictureResult;
 use crate::decoder::stateless::NewStatelessDecoderError;
 use crate::decoder::stateless::StatelessBackendResult;
 use crate::decoder::stateless::StatelessDecoder;
@@ -41,7 +42,7 @@ impl StatelessH264DecoderBackend for Backend {
         Ok(())
     }
 
-    fn new_field_picture(&mut self, _: u64, _: &Self::Handle) -> StatelessBackendResult<()> {
+    fn new_field_picture(&mut self, _: u64, _: &Self::Handle) -> NewPictureResult<()> {
         Ok(())
     }
 
@@ -63,7 +64,7 @@ impl StatelessH264DecoderBackend for Backend {
         })
     }
 
-    fn new_picture(&mut self, _: u64) -> StatelessBackendResult<()> {
+    fn new_picture(&mut self, _: u64) -> NewPictureResult<()> {
         Ok(())
     }
 }

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -35,8 +35,9 @@ use crate::codec::h264::picture::PictureData;
 use crate::codec::h264::picture::Reference;
 use crate::decoder::stateless::h264::StatelessH264DecoderBackend;
 use crate::decoder::stateless::h264::H264;
+use crate::decoder::stateless::NewPictureError;
+use crate::decoder::stateless::NewPictureResult;
 use crate::decoder::stateless::NewStatelessDecoderError;
-use crate::decoder::stateless::StatelessBackendError;
 use crate::decoder::stateless::StatelessBackendResult;
 use crate::decoder::stateless::StatelessDecoder;
 use crate::decoder::stateless::StatelessDecoderBackendPicture;
@@ -540,11 +541,11 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH264DecoderBackend for Vaapi
         self.process_picture::<H264>(picture)
     }
 
-    fn new_picture(&mut self, timestamp: u64) -> StatelessBackendResult<Self::Picture> {
+    fn new_picture(&mut self, timestamp: u64) -> NewPictureResult<Self::Picture> {
         let highest_pool = self.highest_pool();
         let surface = highest_pool
             .get_surface()
-            .ok_or(StatelessBackendError::OutOfResources)?;
+            .ok_or(NewPictureError::OutOfOutputBuffers)?;
 
         let metadata = self.metadata_state.get_parsed()?;
 
@@ -559,7 +560,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH264DecoderBackend for Vaapi
         &mut self,
         timestamp: u64,
         first_field: &Self::Handle,
-    ) -> StatelessBackendResult<Self::Picture> {
+    ) -> NewPictureResult<Self::Picture> {
         // Decode to the same surface as the first field picture.
         Ok(first_field
             .borrow()

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -540,11 +540,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH264DecoderBackend for Vaapi
         self.process_picture::<H264>(picture)
     }
 
-    fn new_picture(
-        &mut self,
-        _: &PictureData,
-        timestamp: u64,
-    ) -> StatelessBackendResult<Self::Picture> {
+    fn new_picture(&mut self, timestamp: u64) -> StatelessBackendResult<Self::Picture> {
         let highest_pool = self.highest_pool();
         let surface = highest_pool
             .get_surface()
@@ -561,7 +557,6 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH264DecoderBackend for Vaapi
 
     fn new_field_picture(
         &mut self,
-        _: &PictureData,
         timestamp: u64,
         first_field: &Self::Handle,
     ) -> StatelessBackendResult<Self::Picture> {

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -936,14 +936,7 @@ where
             return Err(DecodeError::NotEnoughOutputBuffers(1));
         }
 
-        let pps = self
-            .codec
-            .parser
-            .get_pps(slice.header.pic_parameter_set_id)
-            .context("Invalid PPS in handle_picture")?;
-
-        let pps_id = pps.pic_parameter_set_id;
-        self.update_current_set_ids(pps_id)?;
+        self.update_current_set_ids(slice.header.pic_parameter_set_id)?;
         self.renegotiate_if_needed(RenegotiationType::CurrentSps)?;
 
         // We renegotiated and must return the NALU and wait.

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -980,17 +980,21 @@ where
 
         let mut backend_pic = self.backend.new_picture(timestamp)?;
 
+        let pps = self
+            .codec
+            .parser
+            .get_pps(slice.header.pic_parameter_set_id)
+            .context("invalid PPS ID")?;
+        let sps = self
+            .codec
+            .parser
+            .get_sps(pps.seq_parameter_set_id)
+            .context("invalid SPS ID")?;
         self.backend.begin_picture(
             &mut backend_pic,
             &pic,
-            self.codec
-                .parser
-                .get_sps(self.codec.cur_sps_id)
-                .context("Invalid SPS")?,
-            self.codec
-                .parser
-                .get_pps(slice.header.pic_parameter_set_id)
-                .context("Invalid PPS")?,
+            sps,
+            pps,
             &self.codec.dpb,
             &self.codec.rps,
             slice,
@@ -1036,17 +1040,21 @@ where
 
         pic.ref_pic_lists = self.build_ref_pic_lists(&slice.header, &pic.pic)?;
 
+        let pps = self
+            .codec
+            .parser
+            .get_pps(slice.header.pic_parameter_set_id)
+            .context("invalid PPS ID")?;
+        let sps = self
+            .codec
+            .parser
+            .get_sps(pps.seq_parameter_set_id)
+            .context("invalid SPS ID")?;
         self.backend.decode_slice(
             &mut pic.backend_pic,
             slice,
-            self.codec
-                .parser
-                .get_sps(self.codec.cur_sps_id)
-                .context("Invalid SPS id")?,
-            self.codec
-                .parser
-                .get_pps(slice.header.pic_parameter_set_id)
-                .context("Invalid PPS id")?,
+            sps,
+            pps,
             &pic.ref_pic_lists.ref_pic_list0,
             &pic.ref_pic_lists.ref_pic_list1,
         )?;

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -113,11 +113,7 @@ pub trait StatelessH265DecoderBackend:
     fn new_sequence(&mut self, sps: &Sps) -> StatelessBackendResult<()>;
 
     /// Called when the decoder determines that a frame or field was found.
-    fn new_picture(
-        &mut self,
-        picture: &PictureData,
-        timestamp: u64,
-    ) -> StatelessBackendResult<Self::Picture>;
+    fn new_picture(&mut self, timestamp: u64) -> StatelessBackendResult<Self::Picture>;
 
     /// Called by the decoder for every frame or field found.
     #[allow(clippy::too_many_arguments)]
@@ -994,7 +990,7 @@ where
         self.decode_rps(slice, &pic)?;
         self.update_dpb_before_decoding(&pic)?;
 
-        let mut backend_pic = self.backend.new_picture(&pic, timestamp)?;
+        let mut backend_pic = self.backend.new_picture(timestamp)?;
 
         self.backend.begin_picture(
             &mut backend_pic,

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -286,8 +286,6 @@ pub struct H265DecoderState<H: DecodedHandle, P> {
 
     /// The current active SPS id.
     cur_sps_id: u8,
-    /// The current active PPS id.
-    cur_pps_id: u8,
 
     /// Used to identify first picture in decoding order or first picture that
     /// follows an EOS NALU.
@@ -326,7 +324,6 @@ where
             rps: Default::default(),
             dpb: Default::default(),
             cur_sps_id: Default::default(),
-            cur_pps_id: Default::default(),
             first_picture_after_eos: true,
             first_picture_in_bitstream: true,
             prev_tid_0_pic: Default::default(),
@@ -947,7 +944,7 @@ where
             slice,
             self.codec
                 .parser
-                .get_pps(self.codec.cur_pps_id)
+                .get_pps(slice.header.pic_parameter_set_id)
                 .context("Invalid PPS")?,
             self.codec.first_picture_in_bitstream,
             self.codec.first_picture_after_eos,
@@ -992,7 +989,7 @@ where
                 .context("Invalid SPS")?,
             self.codec
                 .parser
-                .get_pps(self.codec.cur_pps_id)
+                .get_pps(slice.header.pic_parameter_set_id)
                 .context("Invalid PPS")?,
             &self.codec.dpb,
             &self.codec.rps,
@@ -1009,7 +1006,6 @@ where
     fn update_current_set_ids(&mut self, pps_id: u8) -> anyhow::Result<()> {
         let pps = self.codec.parser.get_pps(pps_id).context("Invalid PPS")?;
 
-        self.codec.cur_pps_id = pps.pic_parameter_set_id;
         self.codec.cur_sps_id = pps.seq_parameter_set_id;
         Ok(())
     }
@@ -1049,7 +1045,7 @@ where
                 .context("Invalid SPS id")?,
             self.codec
                 .parser
-                .get_pps(self.codec.cur_pps_id)
+                .get_pps(slice.header.pic_parameter_set_id)
                 .context("Invalid PPS id")?,
             &pic.ref_pic_lists.ref_pic_list0,
             &pic.ref_pic_lists.ref_pic_list1,

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -961,7 +961,6 @@ where
             self.codec.first_picture_after_eos,
             self.codec.prev_tid_0_pic.as_ref(),
             self.codec.max_pic_order_cnt_lsb,
-            timestamp,
         );
 
         self.codec.first_picture_after_eos = false;

--- a/src/decoder/stateless/h265/dummy.rs
+++ b/src/decoder/stateless/h265/dummy.rs
@@ -16,6 +16,7 @@ use crate::decoder::stateless::StatelessDecoder;
 use crate::decoder::BlockingMode;
 
 use crate::decoder::stateless::h265::StatelessH265DecoderBackend;
+use crate::Resolution;
 
 impl StatelessH265DecoderBackend for Backend {
     fn new_sequence(
@@ -27,6 +28,7 @@ impl StatelessH265DecoderBackend for Backend {
 
     fn new_picture(
         &mut self,
+        _: Resolution,
         _: u64,
     ) -> crate::decoder::stateless::StatelessBackendResult<Self::Picture> {
         Ok(())

--- a/src/decoder/stateless/h265/dummy.rs
+++ b/src/decoder/stateless/h265/dummy.rs
@@ -30,7 +30,7 @@ impl StatelessH265DecoderBackend for Backend {
         &mut self,
         _: Resolution,
         _: u64,
-    ) -> crate::decoder::stateless::StatelessBackendResult<Self::Picture> {
+    ) -> crate::decoder::stateless::NewPictureResult<Self::Picture> {
         Ok(())
     }
 

--- a/src/decoder/stateless/h265/dummy.rs
+++ b/src/decoder/stateless/h265/dummy.rs
@@ -27,7 +27,6 @@ impl StatelessH265DecoderBackend for Backend {
 
     fn new_picture(
         &mut self,
-        _: &crate::codec::h265::picture::PictureData,
         _: u64,
     ) -> crate::decoder::stateless::StatelessBackendResult<Self::Picture> {
         Ok(())

--- a/src/decoder/stateless/h265/vaapi.rs
+++ b/src/decoder/stateless/h265/vaapi.rs
@@ -594,11 +594,7 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH265DecoderBackend for Vaapi
         self.new_sequence(sps, PoolCreationMode::Highest)
     }
 
-    fn new_picture(
-        &mut self,
-        _: &PictureData,
-        timestamp: u64,
-    ) -> StatelessBackendResult<Self::Picture> {
+    fn new_picture(&mut self, timestamp: u64) -> StatelessBackendResult<Self::Picture> {
         let highest_pool = self.highest_pool();
         let surface = highest_pool
             .get_surface()

--- a/src/decoder/stateless/h265/vaapi.rs
+++ b/src/decoder/stateless/h265/vaapi.rs
@@ -37,9 +37,10 @@ use crate::decoder::stateless::h265::RefPicListEntry;
 use crate::decoder::stateless::h265::RefPicSet;
 use crate::decoder::stateless::h265::StatelessH265DecoderBackend;
 use crate::decoder::stateless::h265::H265;
+use crate::decoder::stateless::NewPictureError;
+use crate::decoder::stateless::NewPictureResult;
 use crate::decoder::stateless::NewStatelessDecoderError;
 use crate::decoder::stateless::PoolLayer;
-use crate::decoder::stateless::StatelessBackendError;
 use crate::decoder::stateless::StatelessBackendResult;
 use crate::decoder::stateless::StatelessDecoder;
 use crate::decoder::stateless::StatelessDecoderBackend;
@@ -601,15 +602,15 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessH265DecoderBackend for Vaapi
         &mut self,
         coded_resolution: Resolution,
         timestamp: u64,
-    ) -> StatelessBackendResult<Self::Picture> {
+    ) -> NewPictureResult<Self::Picture> {
         let layer = PoolLayer::Layer(coded_resolution);
         let pool = self
             .frame_pool(layer)
             .pop()
-            .ok_or(StatelessBackendError::NoFramePool(coded_resolution))?;
+            .ok_or(NewPictureError::NoFramePool(coded_resolution))?;
         let surface = pool
             .get_surface()
-            .ok_or(StatelessBackendError::OutOfResources)?;
+            .ok_or(NewPictureError::OutOfOutputBuffers)?;
         let metadata = self.metadata_state.get_parsed()?;
 
         Ok(VaapiH265Picture {

--- a/src/decoder/stateless/vp8/dummy.rs
+++ b/src/decoder/stateless/vp8/dummy.rs
@@ -25,8 +25,13 @@ impl StatelessVp8DecoderBackend for Backend {
         Ok(())
     }
 
+    fn new_picture(&mut self, _: u64) -> StatelessBackendResult<Self::Picture> {
+        Ok(())
+    }
+
     fn submit_picture(
         &mut self,
+        _: Self::Picture,
         _: &Header,
         _: &Option<Self::Handle>,
         _: &Option<Self::Handle>,
@@ -34,7 +39,6 @@ impl StatelessVp8DecoderBackend for Backend {
         _: &[u8],
         _: &Segmentation,
         _: &MbLfAdjustments,
-        _: u64,
     ) -> StatelessBackendResult<Self::Handle> {
         Ok(Handle {
             handle: Rc::new(RefCell::new(Default::default())),

--- a/src/decoder/stateless/vp8/dummy.rs
+++ b/src/decoder/stateless/vp8/dummy.rs
@@ -15,6 +15,7 @@ use crate::codec::vp8::parser::MbLfAdjustments;
 use crate::codec::vp8::parser::Segmentation;
 use crate::decoder::stateless::vp8::StatelessVp8DecoderBackend;
 use crate::decoder::stateless::vp8::Vp8;
+use crate::decoder::stateless::NewPictureResult;
 use crate::decoder::stateless::NewStatelessDecoderError;
 use crate::decoder::stateless::StatelessBackendResult;
 use crate::decoder::stateless::StatelessDecoder;
@@ -25,7 +26,7 @@ impl StatelessVp8DecoderBackend for Backend {
         Ok(())
     }
 
-    fn new_picture(&mut self, _: u64) -> StatelessBackendResult<Self::Picture> {
+    fn new_picture(&mut self, _: u64) -> NewPictureResult<Self::Picture> {
         Ok(())
     }
 

--- a/src/decoder/stateless/vp8/vaapi.rs
+++ b/src/decoder/stateless/vp8/vaapi.rs
@@ -24,8 +24,9 @@ use crate::codec::vp8::parser::MbLfAdjustments;
 use crate::codec::vp8::parser::Segmentation;
 use crate::decoder::stateless::vp8::StatelessVp8DecoderBackend;
 use crate::decoder::stateless::vp8::Vp8;
+use crate::decoder::stateless::NewPictureError;
+use crate::decoder::stateless::NewPictureResult;
 use crate::decoder::stateless::NewStatelessDecoderError;
-use crate::decoder::stateless::StatelessBackendError;
 use crate::decoder::stateless::StatelessBackendResult;
 use crate::decoder::stateless::StatelessDecoder;
 use crate::decoder::stateless::StatelessDecoderBackendPicture;
@@ -217,11 +218,11 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessVp8DecoderBackend for VaapiB
         self.new_sequence(header, PoolCreationMode::Highest)
     }
 
-    fn new_picture(&mut self, timestamp: u64) -> StatelessBackendResult<Self::Picture> {
+    fn new_picture(&mut self, timestamp: u64) -> NewPictureResult<Self::Picture> {
         let highest_pool = self.highest_pool();
         let surface = highest_pool
             .get_surface()
-            .ok_or(StatelessBackendError::OutOfResources)?;
+            .ok_or(NewPictureError::OutOfOutputBuffers)?;
 
         let metadata = self.metadata_state.get_parsed()?;
 

--- a/src/decoder/stateless/vp9.rs
+++ b/src/decoder/stateless/vp9.rs
@@ -275,11 +275,16 @@ where
                     .ok_or(DecodeError::DecoderError(anyhow!("No pool found")))?
                     .num_free_frames();
 
+                let num_required_frames = frames
+                    .iter()
+                    .filter(|f| !f.header.show_existing_frame)
+                    .count();
+
                 if matches!(self.decoding_state, DecodingState::Decoding)
-                    && num_free_frames < frames.len()
+                    && num_free_frames < num_required_frames
                 {
                     return Err(DecodeError::NotEnoughOutputBuffers(
-                        frames.len() - num_free_frames,
+                        num_required_frames - num_free_frames,
                     ));
                 }
 

--- a/src/decoder/stateless/vp9.rs
+++ b/src/decoder/stateless/vp9.rs
@@ -272,13 +272,15 @@ where
             }
         }
 
-        for frame in frames {
-            match &mut self.decoding_state {
-                // Skip input until we get information from the stream.
-                DecodingState::AwaitingStreamInfo | DecodingState::Reset => (),
-                // Ask the client to confirm the format before we can process this.
-                DecodingState::AwaitingFormat(_) => return Err(DecodeError::CheckEvents),
-                DecodingState::Decoding => self.handle_frame(&frame, timestamp)?,
+        match &mut self.decoding_state {
+            // Skip input until we get information from the stream.
+            DecodingState::AwaitingStreamInfo | DecodingState::Reset => (),
+            // Ask the client to confirm the format before we can process this.
+            DecodingState::AwaitingFormat(_) => return Err(DecodeError::CheckEvents),
+            DecodingState::Decoding => {
+                for frame in frames {
+                    self.handle_frame(&frame, timestamp)?;
+                }
             }
         }
 

--- a/src/decoder/stateless/vp9/dummy.rs
+++ b/src/decoder/stateless/vp9/dummy.rs
@@ -26,12 +26,16 @@ impl StatelessVp9DecoderBackend for Backend {
         Ok(())
     }
 
+    fn new_picture(&mut self, _: u64) -> StatelessBackendResult<Self::Picture> {
+        Ok(())
+    }
+
     fn submit_picture(
         &mut self,
+        _: Self::Picture,
         _: &Header,
         _: &[Option<Self::Handle>; NUM_REF_FRAMES],
         _: &[u8],
-        _: u64,
         _: &[Segmentation; MAX_SEGMENTS],
     ) -> StatelessBackendResult<Self::Handle> {
         Ok(Handle {

--- a/src/decoder/stateless/vp9/dummy.rs
+++ b/src/decoder/stateless/vp9/dummy.rs
@@ -16,6 +16,7 @@ use crate::codec::vp9::parser::NUM_REF_FRAMES;
 use crate::decoder::stateless::vp9::Segmentation;
 use crate::decoder::stateless::vp9::StatelessVp9DecoderBackend;
 use crate::decoder::stateless::vp9::Vp9;
+use crate::decoder::stateless::NewPictureResult;
 use crate::decoder::stateless::NewStatelessDecoderError;
 use crate::decoder::stateless::StatelessBackendResult;
 use crate::decoder::stateless::StatelessDecoder;
@@ -26,7 +27,7 @@ impl StatelessVp9DecoderBackend for Backend {
         Ok(())
     }
 
-    fn new_picture(&mut self, _: u64) -> StatelessBackendResult<Self::Picture> {
+    fn new_picture(&mut self, _: u64) -> NewPictureResult<Self::Picture> {
         Ok(())
     }
 

--- a/src/decoder/stateless/vp9/vaapi.rs
+++ b/src/decoder/stateless/vp9/vaapi.rs
@@ -253,17 +253,17 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessVp9DecoderBackend for VaapiB
         timestamp: u64,
         segmentation: &[Segmentation; MAX_SEGMENTS],
     ) -> StatelessBackendResult<Self::Handle> {
+        let highest_pool = self.highest_pool();
+        let surface = highest_pool
+            .get_surface()
+            .ok_or(StatelessBackendError::OutOfResources)?;
+
         let reference_frames: [u32; NUM_REF_FRAMES] = reference_frames
             .iter()
             .map(va_surface_id)
             .collect::<Vec<_>>()
             .try_into()
             .unwrap();
-
-        let highest_pool = self.highest_pool();
-        let surface = highest_pool
-            .get_surface()
-            .ok_or(StatelessBackendError::OutOfResources)?;
 
         let metadata = self.metadata_state.get_parsed()?;
         let context = &metadata.context;

--- a/src/decoder/stateless/vp9/vaapi.rs
+++ b/src/decoder/stateless/vp9/vaapi.rs
@@ -27,8 +27,9 @@ use crate::codec::vp9::parser::NUM_REF_FRAMES;
 use crate::decoder::stateless::vp9::Segmentation;
 use crate::decoder::stateless::vp9::StatelessVp9DecoderBackend;
 use crate::decoder::stateless::vp9::Vp9;
+use crate::decoder::stateless::NewPictureError;
+use crate::decoder::stateless::NewPictureResult;
 use crate::decoder::stateless::NewStatelessDecoderError;
-use crate::decoder::stateless::StatelessBackendError;
 use crate::decoder::stateless::StatelessBackendResult;
 use crate::decoder::stateless::StatelessDecoder;
 use crate::decoder::stateless::StatelessDecoderBackendPicture;
@@ -246,11 +247,11 @@ impl<M: SurfaceMemoryDescriptor + 'static> StatelessVp9DecoderBackend for VaapiB
         self.new_sequence(header, PoolCreationMode::Highest)
     }
 
-    fn new_picture(&mut self, timestamp: u64) -> StatelessBackendResult<Self::Picture> {
+    fn new_picture(&mut self, timestamp: u64) -> NewPictureResult<Self::Picture> {
         let highest_pool = self.highest_pool();
         let surface = highest_pool
             .get_surface()
-            .ok_or(StatelessBackendError::OutOfResources)?;
+            .ok_or(NewPictureError::OutOfOutputBuffers)?;
         let metadata = self.metadata_state.get_parsed()?;
         let context = &metadata.context;
 


### PR DESCRIPTION
This series fixes a design shortcoming in the decoder, namely that it was checking for output buffers availability before deciding to initiate a picture with the backend.

This was working well for the VAAPI backend, which must secure its output surface to create a `VAPicture`, but is not appropriate for V4L2 where the input and output queues are completely independent.

Each codec has a series of CLs culminating with `let the backend decide which resources it needs`, which moves the burden of checking output surfaces availability from the decoder to the VAAPI backend. That way the V4L2 backend is not constrained by output resources, and can decide itself which resources it needs to acquire to create a picture (in its case, an input buffer).

The other CLs include changes that are necessary to reach this state, e.g. rework of the backend interface to separate picture creation from submission when needed, and reordering of the format negotiation flow.

Sorry for the number of CLs ; however they should be bite-sized and relatively easy to understand.