### PR TITLE
Handover of final codec fixes

### DIFF
--- a/src/codec/av1/parser.rs
+++ b/src/codec/av1/parser.rs
@@ -121,17 +121,15 @@ impl ObuHeader {
 pub struct Obu<'a> {
     /// The OBU header.
     pub header: ObuHeader,
-    /// The data backing the OBU.
-    pub data: Cow<'a, [u8]>,
-    /// Where the OBU data starts, after the size has been read.
-    pub start_offset: usize,
-    /// The OBU size as per the specification after `start_offset`.
-    pub size: usize,
+    /// Amount of bytes from the input consumed to parse this OBU.
+    pub bytes_used: usize,
+    /// The slice backing the OBU.
+    data: Cow<'a, [u8]>,
 }
 
 impl<'a> AsRef<[u8]> for Obu<'a> {
     fn as_ref(&self) -> &[u8] {
-        &self.data[self.start_offset..self.start_offset + self.size]
+        self.data.as_ref()
     }
 }
 
@@ -1453,7 +1451,7 @@ impl Parser {
         // We can't have that in parse_obu as per the spec, because the reader
         // is not initialized on our design at that point, so move the check to
         // inside this function.
-        if obu.size == 0
+        if obu.data.len() == 0
             || matches!(
                 obu.header.obu_type,
                 ObuType::TileList | ObuType::TileGroup | ObuType::Frame
@@ -1580,9 +1578,8 @@ impl Parser {
 
         Ok(ParsedObu::Process(Obu {
             header,
-            data: Cow::from(&data[..start_offset + obu_size]),
-            start_offset,
-            size: obu_size,
+            data: Cow::from(&data[start_offset..start_offset + obu_size]),
+            bytes_used: start_offset + obu_size,
         }))
     }
 
@@ -3648,9 +3645,11 @@ impl Parser {
         let frame_header_obu = self.parse_frame_header_obu(&obu)?;
         let obu = Obu {
             header: obu.header,
-            data: obu.data,
-            start_offset: obu.start_offset + frame_header_obu.header_bytes,
-            size: obu.size - frame_header_obu.header_bytes,
+            data: match obu.data {
+                Cow::Borrowed(d) => Cow::Borrowed(&d[frame_header_obu.header_bytes..]),
+                Cow::Owned(d) => Cow::Owned(d[frame_header_obu.header_bytes..].to_owned()),
+            },
+            bytes_used: obu.bytes_used,
         };
         let tile_group_obu = self.parse_tile_group_obu(obu)?;
 
@@ -3858,7 +3857,7 @@ mod tests {
                         continue;
                     }
                 };
-                consumed += obu.data.len();
+                consumed += obu.bytes_used;
                 num_obus += 1;
             }
         }
@@ -3908,7 +3907,7 @@ mod tests {
                     }
                 };
                 assert!(matches!(parser.stream_format, StreamFormat::LowOverhead));
-                consumed += obu.data.len();
+                consumed += obu.bytes_used;
             }
         }
 
@@ -3929,7 +3928,7 @@ mod tests {
                     }
                 };
                 assert!(matches!(parser.stream_format, StreamFormat::AnnexB { .. }));
-                consumed += obu.data.len();
+                consumed += obu.bytes_used;
                 num_obus += 1;
             }
         }
@@ -3967,7 +3966,7 @@ mod tests {
                     }
                 };
 
-                let data_len = obu.data.len();
+                let data_len = obu.bytes_used;
 
                 match obu.header.obu_type {
                     ObuType::SequenceHeader => {

--- a/src/codec/av1/parser.rs
+++ b/src/codec/av1/parser.rs
@@ -135,6 +135,49 @@ impl<'a> AsRef<[u8]> for Obu<'a> {
     }
 }
 
+/// A fully parsed OBU, with additional data when relevant.
+pub enum ParsedObu<'a> {
+    Reserved,
+    SequenceHeader(Rc<SequenceHeaderObu>),
+    TemporalDelimiter,
+    FrameHeader(FrameHeaderObu),
+    TileGroup(TileGroupObu<'a>),
+    Metadata,
+    Frame(FrameObu<'a>),
+    RedundantFrameHeader,
+    TileList,
+    Reserved2,
+    Reserved3,
+    Reserved4,
+    Reserved5,
+    Reserved6,
+    Reserved7,
+    Padding,
+}
+
+impl<'a> ParsedObu<'a> {
+    pub fn obu_type(&self) -> ObuType {
+        match self {
+            ParsedObu::Reserved => ObuType::Reserved,
+            ParsedObu::SequenceHeader(_) => ObuType::SequenceHeader,
+            ParsedObu::TemporalDelimiter => ObuType::TemporalDelimiter,
+            ParsedObu::FrameHeader(_) => ObuType::FrameHeader,
+            ParsedObu::TileGroup(_) => ObuType::TileGroup,
+            ParsedObu::Metadata => ObuType::Metadata,
+            ParsedObu::Frame(_) => ObuType::Frame,
+            ParsedObu::RedundantFrameHeader => ObuType::RedundantFrameHeader,
+            ParsedObu::TileList => ObuType::TileList,
+            ParsedObu::Reserved2 => ObuType::Reserved2,
+            ParsedObu::Reserved3 => ObuType::Reserved3,
+            ParsedObu::Reserved4 => ObuType::Reserved4,
+            ParsedObu::Reserved5 => ObuType::Reserved5,
+            ParsedObu::Reserved6 => ObuType::Reserved6,
+            ParsedObu::Reserved7 => ObuType::Reserved7,
+            ParsedObu::Padding => ObuType::Padding,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Tile {
     /// Same as TileOffset in the specification.
@@ -1720,29 +1763,12 @@ impl Parser {
         Ok(())
     }
 
-    pub fn parse_temporal_delimiter_obu(&mut self, obu: &Obu) -> anyhow::Result<()> {
-        if !matches!(obu.header.obu_type, ObuType::TemporalDelimiter) {
-            return Err(anyhow!(
-                "Expected a TemporalDelimiterOBU, got {:?}",
-                obu.header.obu_type
-            ));
-        }
-
+    fn parse_temporal_delimiter_obu(&mut self) -> anyhow::Result<()> {
         self.seen_frame_header = false;
         Ok(())
     }
 
-    pub fn parse_sequence_header_obu(
-        &mut self,
-        obu: &Obu,
-    ) -> anyhow::Result<Rc<SequenceHeaderObu>> {
-        if !matches!(obu.header.obu_type, ObuType::SequenceHeader) {
-            return Err(anyhow!(
-                "Expected a SequenceHeaderOBU, got {:?}",
-                obu.header.obu_type
-            ));
-        }
-
+    fn parse_sequence_header_obu(&mut self, obu: &Obu) -> anyhow::Result<Rc<SequenceHeaderObu>> {
         let mut s = SequenceHeaderObu {
             obu_header: obu.header.clone(),
             ..Default::default()
@@ -3551,7 +3577,7 @@ impl Parser {
         Ok(fh)
     }
 
-    pub fn parse_tile_group_obu<'a>(&mut self, obu: Obu<'a>) -> anyhow::Result<TileGroupObu<'a>> {
+    fn parse_tile_group_obu<'a>(&mut self, obu: Obu<'a>) -> anyhow::Result<TileGroupObu<'a>> {
         let mut tg = TileGroupObu {
             obu,
             ..Default::default()
@@ -3636,14 +3662,7 @@ impl Parser {
         Ok(tg)
     }
 
-    pub fn parse_frame_obu<'a>(&mut self, obu: Obu<'a>) -> anyhow::Result<FrameObu<'a>> {
-        if !matches!(obu.header.obu_type, ObuType::Frame) {
-            return Err(anyhow!(
-                "Expected a FrameOBU, got {:?}",
-                obu.header.obu_type
-            ));
-        }
-
+    fn parse_frame_obu<'a>(&mut self, obu: Obu<'a>) -> anyhow::Result<FrameObu<'a>> {
         let frame_header_obu = self.parse_frame_header_obu(&obu)?;
         let obu = Obu {
             header: obu.header,
@@ -3757,6 +3776,34 @@ impl Parser {
             None
         } else {
             Some(helpers::floor_log2((self.operating_point_idc >> 8) as u32))
+        }
+    }
+
+    /// Fully parse an OBU.
+    pub fn parse_obu<'a>(&mut self, obu: Obu<'a>) -> anyhow::Result<ParsedObu<'a>> {
+        match obu.header.obu_type {
+            ObuType::Reserved => Ok(ParsedObu::Reserved),
+            ObuType::SequenceHeader => self
+                .parse_sequence_header_obu(&obu)
+                .map(ParsedObu::SequenceHeader),
+            ObuType::TemporalDelimiter => self
+                .parse_temporal_delimiter_obu()
+                .map(|_| ParsedObu::TemporalDelimiter),
+            ObuType::FrameHeader => self
+                .parse_frame_header_obu(&obu)
+                .map(ParsedObu::FrameHeader),
+            ObuType::TileGroup => self.parse_tile_group_obu(obu).map(ParsedObu::TileGroup),
+            ObuType::Metadata => Ok(ParsedObu::Metadata),
+            ObuType::Frame => self.parse_frame_obu(obu).map(ParsedObu::Frame),
+            ObuType::RedundantFrameHeader => Ok(ParsedObu::RedundantFrameHeader),
+            ObuType::TileList => Ok(ParsedObu::TileList),
+            ObuType::Reserved2 => Ok(ParsedObu::Reserved2),
+            ObuType::Reserved3 => Ok(ParsedObu::Reserved3),
+            ObuType::Reserved4 => Ok(ParsedObu::Reserved4),
+            ObuType::Reserved5 => Ok(ParsedObu::Reserved5),
+            ObuType::Reserved6 => Ok(ParsedObu::Reserved6),
+            ObuType::Reserved7 => Ok(ParsedObu::Reserved7),
+            ObuType::Padding => Ok(ParsedObu::Padding),
         }
     }
 }

--- a/src/codec/av1/parser.rs
+++ b/src/codec/av1/parser.rs
@@ -1944,7 +1944,7 @@ impl Parser {
     /// header, so we must save them now, as they will not be parsed from the
     /// bitstream. We also save some internal parser state which will be useful
     /// later.
-    fn load_reference_frame(&mut self, fh: &mut FrameHeaderObu) -> anyhow::Result<()> {
+    fn load_reference_frame(&self, fh: &mut FrameHeaderObu) -> anyhow::Result<()> {
         let rf = &self.ref_info[fh.frame_to_show_map_idx as usize];
 
         // Section 6.8.1: It is a requirement of bitstream conformance that a

--- a/src/codec/h264/dpb.rs
+++ b/src/codec/h264/dpb.rs
@@ -255,8 +255,8 @@ impl<T: Clone> Dpb<T> {
         Some(&self.entries[position])
     }
 
-    /// Store a picture and its backend handle in the DPB.
-    fn store_picture(
+    /// Store `picture` and its backend handle in the DPB.
+    pub fn store_picture(
         &mut self,
         picture: RcPictureData,
         handle: Option<T>,
@@ -291,40 +291,6 @@ impl<T: Clone> Dpb<T> {
             decoded_frame: handle,
             needed_for_output,
         });
-
-        Ok(())
-    }
-
-    /// Add `pic` and its associated `handle` to the DPB.
-    pub fn add_picture(
-        &mut self,
-        pic: RcPictureData,
-        handle: Option<T>,
-        last_field: &mut Option<(RcPictureData, T)>,
-    ) -> Result<(), StorePictureError> {
-        if !self.interlaced() {
-            assert!(last_field.is_none());
-
-            self.store_picture(pic, handle)?;
-        } else {
-            // If we have a cached field for this picture, we must combine
-            // them before insertion.
-            if pic
-                .borrow()
-                .other_field()
-                .zip(last_field.as_ref().map(|f| &f.0))
-                .map_or_else(
-                    || false,
-                    |(other_field, last_field)| Rc::ptr_eq(&other_field, last_field),
-                )
-            {
-                if let Some((last_field, last_field_handle)) = last_field.take() {
-                    self.store_picture(last_field, Some(last_field_handle))?;
-                }
-            }
-
-            self.store_picture(pic, handle)?;
-        }
 
         Ok(())
     }

--- a/src/codec/h264/nalu_reader.rs
+++ b/src/codec/h264/nalu_reader.rs
@@ -170,7 +170,7 @@ impl<'a> NaluReader<'a> {
         let ue = self.read_ue::<u32>()? as i32;
 
         if ue % 2 == 0 {
-            Ok(U::try_from(-ue / 2).map_err(|_| anyhow!("Conversion error"))?)
+            Ok(U::try_from(-(ue / 2)).map_err(|_| anyhow!("Conversion error"))?)
         } else {
             Ok(U::try_from(ue / 2 + 1).map_err(|_| anyhow!("Conversion error"))?)
         }

--- a/src/codec/h264/nalu_reader.rs
+++ b/src/codec/h264/nalu_reader.rs
@@ -136,10 +136,9 @@ impl<'a> NaluReader<'a> {
 
         while self.read_bits::<u32>(1)? == 0 {
             num_bits += 1;
-        }
-
-        if num_bits > 31 {
-            return Err(anyhow!("invalid stream"));
+            if num_bits > 31 {
+                return Err(anyhow!("invalid stream"));
+            }
         }
 
         let value = ((1u32 << num_bits) - 1)

--- a/src/codec/h264/nalu_reader.rs
+++ b/src/codec/h264/nalu_reader.rs
@@ -35,7 +35,7 @@ pub(crate) enum GetByteError {
 #[derive(Debug, Error)]
 pub(crate) enum ReadBitsError {
     #[error("more than 31 ({0}) bits were requested")]
-    TooManyBytesRequested(usize),
+    TooManyBitsRequested(usize),
     #[error("failed to advance the current byte")]
     GetByte(#[from] GetByteError),
     #[error("failed to convert read input to target type")]
@@ -66,7 +66,7 @@ impl<'a> NaluReader<'a> {
     /// Read up to 31 bits from the stream.
     pub fn read_bits<U: TryFrom<u32>>(&mut self, num_bits: usize) -> Result<U, ReadBitsError> {
         if num_bits > 31 {
-            return Err(ReadBitsError::TooManyBytesRequested(num_bits));
+            return Err(ReadBitsError::TooManyBitsRequested(num_bits));
         }
 
         let mut bits_left = num_bits;

--- a/src/codec/h265/parser.rs
+++ b/src/codec/h265/parser.rs
@@ -2091,7 +2091,7 @@ impl Default for VuiParams {
 pub struct Parser {
     active_vpses: BTreeMap<u8, Vps>,
     active_spses: BTreeMap<u8, Rc<Sps>>,
-    active_ppses: BTreeMap<u8, Pps>,
+    active_ppses: BTreeMap<u8, Rc<Pps>>,
 }
 
 impl Parser {
@@ -3482,6 +3482,7 @@ impl Parser {
         );
 
         let key = pps.pic_parameter_set_id;
+        let pps = Rc::new(pps);
         self.active_ppses.insert(key, pps);
 
         if self.active_ppses.keys().len() > MAX_PPS_COUNT {
@@ -4047,7 +4048,7 @@ impl Parser {
     }
 
     /// Returns a previously parsed pps given `pps_id`, if any.
-    pub fn get_pps(&self, pps_id: u8) -> Option<&Pps> {
+    pub fn get_pps(&self, pps_id: u8) -> Option<&Rc<Pps>> {
         self.active_ppses.get(&pps_id)
     }
 }

--- a/src/codec/h265/parser.rs
+++ b/src/codec/h265/parser.rs
@@ -181,6 +181,12 @@ pub struct NaluHeader {
     pub nuh_temporal_id_plus1: u8,
 }
 
+impl NaluHeader {
+    pub fn nuh_temporal_id(&self) -> u8 {
+        self.nuh_temporal_id_plus1.saturating_sub(1)
+    }
+}
+
 impl Header for NaluHeader {
     fn parse<T: AsRef<[u8]>>(cursor: &std::io::Cursor<T>) -> anyhow::Result<Self> {
         let data = &cursor.chunk()[0..2];
@@ -1218,9 +1224,6 @@ pub struct Pps {
     // Internal variables.
     /// Equivalent to QpBdOffsetY in the specification.
     pub qp_bd_offset_y: u32,
-
-    /// The nuh_temporal_id_plus1 - 1 of the associated NALU.
-    pub temporal_id: u8,
 }
 
 impl Default for Pps {
@@ -1271,7 +1274,6 @@ impl Default for Pps {
             qp_bd_offset_y: Default::default(),
             scc_extension: Default::default(),
             scc_extension_flag: Default::default(),
-            temporal_id: Default::default(),
         }
     }
 }
@@ -3475,8 +3477,6 @@ impl Parser {
 
             r.skip_bits(4)?; // pps_extension_4bits
         }
-
-        pps.temporal_id = nalu.header.nuh_temporal_id_plus1 - 1;
 
         log::debug!(
             "Parsed PPS({}), NAL size was {}",

--- a/src/codec/h265/parser.rs
+++ b/src/codec/h265/parser.rs
@@ -839,6 +839,9 @@ pub struct Sps {
     pub max_tb_log2_size_y: u32,
     /// Equivalent to PicSizeInSamplesY in the specification.
     pub pic_size_in_samples_y: u32,
+
+    /// The VPS referenced by this SPS, if any.
+    pub vps: Option<Rc<Vps>>,
 }
 
 impl Sps {
@@ -2980,10 +2983,16 @@ impl Parser {
         // Skip the header
         let mut r = NaluReader::new(&data[hdr_len..]);
 
+        let video_parameter_set_id = r.read_bits(4)?;
+
+        // A non-existing VPS means the SPS is not using any VPS.
+        let vps = self.get_vps(video_parameter_set_id).cloned();
+
         let mut sps = Sps {
-            video_parameter_set_id: r.read_bits(4)?,
+            video_parameter_set_id,
             max_sub_layers_minus1: r.read_bits(3)?,
             temporal_id_nesting_flag: r.read_bit()?,
+            vps,
             ..Default::default()
         };
 

--- a/src/codec/h265/parser.rs
+++ b/src/codec/h265/parser.rs
@@ -2089,7 +2089,7 @@ impl Default for VuiParams {
 
 #[derive(Clone, Debug, Default)]
 pub struct Parser {
-    active_vpses: BTreeMap<u8, Vps>,
+    active_vpses: BTreeMap<u8, Rc<Vps>>,
     active_spses: BTreeMap<u8, Rc<Sps>>,
     active_ppses: BTreeMap<u8, Rc<Pps>>,
 }
@@ -2233,6 +2233,7 @@ impl Parser {
         }
 
         let key = vps.video_parameter_set_id;
+        let vps = Rc::new(vps);
         self.active_vpses.remove(&key);
         Ok(self.active_vpses.entry(key).or_insert(vps))
     }
@@ -4036,7 +4037,7 @@ impl Parser {
     }
 
     /// Returns a previously parsed vps given `vps_id`, if any.
-    pub fn get_vps(&self, vps_id: u8) -> Option<&Vps> {
+    pub fn get_vps(&self, vps_id: u8) -> Option<&Rc<Vps>> {
         self.active_vpses.get(&vps_id)
     }
 

--- a/src/codec/h265/parser.rs
+++ b/src/codec/h265/parser.rs
@@ -2275,9 +2275,9 @@ impl Parser {
         let key = vps.video_parameter_set_id;
         self.active_vpses.insert(key, vps);
 
-        if self.active_spses.keys().len() > MAX_VPS_COUNT {
+        if self.active_vpses.keys().len() > MAX_VPS_COUNT {
             return Err(anyhow!(
-                "Broken data: Number of active SPSs > MAX_SPS_COUNT"
+                "Broken data: Number of active VPSs > MAX_VPS_COUNT"
             ));
         }
 

--- a/src/codec/h265/parser.rs
+++ b/src/codec/h265/parser.rs
@@ -7,6 +7,7 @@
 //! Parses VPSs, SPSs, PPSs and Slices from NALUs.
 
 use std::collections::BTreeMap;
+use std::rc::Rc;
 
 use anyhow::anyhow;
 use anyhow::Context;
@@ -1224,58 +1225,9 @@ pub struct Pps {
     // Internal variables.
     /// Equivalent to QpBdOffsetY in the specification.
     pub qp_bd_offset_y: u32,
-}
 
-impl Default for Pps {
-    fn default() -> Self {
-        Self {
-            pic_parameter_set_id: Default::default(),
-            seq_parameter_set_id: Default::default(),
-            dependent_slice_segments_enabled_flag: Default::default(),
-            output_flag_present_flag: Default::default(),
-            num_extra_slice_header_bits: Default::default(),
-            sign_data_hiding_enabled_flag: Default::default(),
-            cabac_init_present_flag: Default::default(),
-            num_ref_idx_l0_default_active_minus1: Default::default(),
-            num_ref_idx_l1_default_active_minus1: Default::default(),
-            init_qp_minus26: Default::default(),
-            constrained_intra_pred_flag: Default::default(),
-            transform_skip_enabled_flag: Default::default(),
-            cu_qp_delta_enabled_flag: Default::default(),
-            diff_cu_qp_delta_depth: Default::default(),
-            cb_qp_offset: Default::default(),
-            cr_qp_offset: Default::default(),
-            slice_chroma_qp_offsets_present_flag: Default::default(),
-            weighted_pred_flag: Default::default(),
-            weighted_bipred_flag: Default::default(),
-            transquant_bypass_enabled_flag: Default::default(),
-            tiles_enabled_flag: Default::default(),
-            entropy_coding_sync_enabled_flag: Default::default(),
-            num_tile_columns_minus1: Default::default(),
-            num_tile_rows_minus1: Default::default(),
-            uniform_spacing_flag: true,
-            column_width_minus1: Default::default(),
-            row_height_minus1: Default::default(),
-            loop_filter_across_tiles_enabled_flag: true,
-            loop_filter_across_slices_enabled_flag: Default::default(),
-            deblocking_filter_control_present_flag: Default::default(),
-            deblocking_filter_override_enabled_flag: Default::default(),
-            deblocking_filter_disabled_flag: Default::default(),
-            beta_offset_div2: Default::default(),
-            tc_offset_div2: Default::default(),
-            scaling_list_data_present_flag: Default::default(),
-            scaling_list: Default::default(),
-            lists_modification_present_flag: Default::default(),
-            log2_parallel_merge_level_minus2: Default::default(),
-            slice_segment_header_extension_present_flag: Default::default(),
-            extension_present_flag: Default::default(),
-            range_extension_flag: Default::default(),
-            range_extension: Default::default(),
-            qp_bd_offset_y: Default::default(),
-            scc_extension: Default::default(),
-            scc_extension_flag: Default::default(),
-        }
-    }
+    /// The SPS referenced by this PPS.
+    pub sps: Rc<Sps>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -2138,7 +2090,7 @@ impl Default for VuiParams {
 #[derive(Clone, Debug, Default)]
 pub struct Parser {
     active_vpses: BTreeMap<u8, Vps>,
-    active_spses: BTreeMap<u8, Sps>,
+    active_spses: BTreeMap<u8, Rc<Sps>>,
     active_ppses: BTreeMap<u8, Pps>,
 }
 
@@ -3220,6 +3172,7 @@ impl Parser {
         );
 
         let key = sps.seq_parameter_set_id;
+        let sps = Rc::new(sps);
         self.active_spses.insert(key, sps);
 
         if self.active_spses.keys().len() > MAX_SPS_COUNT {
@@ -3325,18 +3278,62 @@ impl Parser {
         // Skip the header
         let mut r = NaluReader::new(&data[hdr_len..]);
 
-        let mut pps = Pps {
-            loop_filter_across_tiles_enabled_flag: true,
-            ..Default::default()
-        };
+        let pic_parameter_set_id = r.read_ue_max(MAX_PPS_COUNT as u32 - 1)?;
+        let seq_parameter_set_id = r.read_ue_max(MAX_SPS_COUNT as u32 - 1)?;
 
-        pps.pic_parameter_set_id = r.read_ue_max(MAX_PPS_COUNT as u32 - 1)?;
-        pps.seq_parameter_set_id = r.read_ue_max(MAX_SPS_COUNT as u32 - 1)?;
-
-        let sps = self.get_sps(pps.seq_parameter_set_id).context(format!(
+        let sps = self.get_sps(seq_parameter_set_id).context(format!(
             "Broken stream: stream references SPS {} that has not been successfully parsed",
-            pps.seq_parameter_set_id
+            seq_parameter_set_id
         ))?;
+
+        let mut pps = Pps {
+            pic_parameter_set_id,
+            seq_parameter_set_id,
+            dependent_slice_segments_enabled_flag: Default::default(),
+            output_flag_present_flag: Default::default(),
+            num_extra_slice_header_bits: Default::default(),
+            sign_data_hiding_enabled_flag: Default::default(),
+            cabac_init_present_flag: Default::default(),
+            num_ref_idx_l0_default_active_minus1: Default::default(),
+            num_ref_idx_l1_default_active_minus1: Default::default(),
+            init_qp_minus26: Default::default(),
+            constrained_intra_pred_flag: Default::default(),
+            transform_skip_enabled_flag: Default::default(),
+            cu_qp_delta_enabled_flag: Default::default(),
+            diff_cu_qp_delta_depth: Default::default(),
+            cb_qp_offset: Default::default(),
+            cr_qp_offset: Default::default(),
+            slice_chroma_qp_offsets_present_flag: Default::default(),
+            weighted_pred_flag: Default::default(),
+            weighted_bipred_flag: Default::default(),
+            transquant_bypass_enabled_flag: Default::default(),
+            tiles_enabled_flag: Default::default(),
+            entropy_coding_sync_enabled_flag: Default::default(),
+            num_tile_columns_minus1: Default::default(),
+            num_tile_rows_minus1: Default::default(),
+            uniform_spacing_flag: true,
+            column_width_minus1: Default::default(),
+            row_height_minus1: Default::default(),
+            loop_filter_across_tiles_enabled_flag: true,
+            loop_filter_across_slices_enabled_flag: Default::default(),
+            deblocking_filter_control_present_flag: Default::default(),
+            deblocking_filter_override_enabled_flag: Default::default(),
+            deblocking_filter_disabled_flag: Default::default(),
+            beta_offset_div2: Default::default(),
+            tc_offset_div2: Default::default(),
+            scaling_list_data_present_flag: Default::default(),
+            scaling_list: Default::default(),
+            lists_modification_present_flag: Default::default(),
+            log2_parallel_merge_level_minus2: Default::default(),
+            slice_segment_header_extension_present_flag: Default::default(),
+            extension_present_flag: Default::default(),
+            range_extension_flag: Default::default(),
+            range_extension: Default::default(),
+            qp_bd_offset_y: Default::default(),
+            scc_extension: Default::default(),
+            scc_extension_flag: Default::default(),
+            sps: Rc::clone(sps),
+        };
 
         pps.dependent_slice_segments_enabled_flag = r.read_bit()?;
         pps.output_flag_present_flag = r.read_bit()?;
@@ -3681,11 +3678,7 @@ impl Parser {
             )
         })?;
 
-        let sps = self.get_sps(pps.seq_parameter_set_id).with_context(|| {
-            format!(
-            "Broken stream: slice's PPS references SPS {} that has not been successfully parsed.", pps.seq_parameter_set_id
-        )
-        })?;
+        let sps = &pps.sps;
 
         Self::slice_header_set_defaults(&mut hdr, sps, pps);
 
@@ -4049,7 +4042,7 @@ impl Parser {
     }
 
     /// Returns a previously parsed sps given `sps_id`, if any.
-    pub fn get_sps(&self, sps_id: u8) -> Option<&Sps> {
+    pub fn get_sps(&self, sps_id: u8) -> Option<&Rc<Sps>> {
         self.active_spses.get(&sps_id)
     }
 

--- a/src/codec/h265/picture.rs
+++ b/src/codec/h265/picture.rs
@@ -29,7 +29,6 @@ pub struct PictureData {
     pub no_output_of_prior_pics_flag: bool,
 
     // Internal state.
-    pub is_irap: bool,
     pub first_picture_after_eos: bool,
     reference: Reference,
     pub pic_latency_cnt: i32,
@@ -54,7 +53,6 @@ impl PictureData {
     ) -> Self {
         let hdr = &slice.header;
         let nalu_type = slice.nalu.header.type_;
-        let is_irap = nalu_type.is_irap();
 
         // We assume HandleCraAsBlafFLag == 0, as it is only set through
         // external means, which we do not provide.
@@ -81,7 +79,7 @@ impl PictureData {
 
         // Compute the Picture Order Count. See 8.3.1 Decoding Process for
         // Picture Order Count
-        if !(is_irap && no_rasl_output_flag) {
+        if !(nalu_type.is_irap() && no_rasl_output_flag) {
             if let Some(prev_tid0_pic) = prev_tid0_pic {
                 // Equation (8-1)
                 let prev_pic_order_cnt_lsb = prev_tid0_pic.slice_pic_order_cnt_lsb;
@@ -131,7 +129,6 @@ impl PictureData {
             pic_order_cnt_msb,
             // Equation (8-2)
             pic_order_cnt_val: pic_order_cnt_msb + slice_pic_order_cnt_lsb,
-            is_irap,
             first_picture_after_eos,
             reference: Default::default(),
             pic_latency_cnt: 0,

--- a/src/codec/h265/picture.rs
+++ b/src/codec/h265/picture.rs
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 use crate::codec::h265::parser::NaluType;
-use crate::codec::h265::parser::Pps;
 use crate::codec::h265::parser::Slice;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
@@ -48,7 +47,6 @@ impl PictureData {
     /// correctly initialize the POC values.
     pub fn new_from_slice(
         slice: &Slice,
-        pps: &Pps,
         first_picture_in_bitstream: bool,
         first_picture_after_eos: bool,
         prev_tid0_pic: Option<&PictureData>,
@@ -111,7 +109,7 @@ impl PictureData {
         //
         // Use this flag to correctly set up the field in the decoder during
         // `finish_picture`.
-        let valid_for_prev_tid0_pic = pps.temporal_id == 0
+        let valid_for_prev_tid0_pic = slice.nalu.header.nuh_temporal_id() == 0
             && !nalu_type.is_radl()
             && !nalu_type.is_rasl()
             && !nalu_type.is_slnr();

--- a/src/decoder/stateless.rs
+++ b/src/decoder/stateless.rs
@@ -18,7 +18,9 @@ pub mod vp8;
 pub mod vp9;
 
 use std::os::fd::AsFd;
+use std::os::fd::AsRawFd;
 use std::os::fd::BorrowedFd;
+use std::time::Duration;
 
 use nix::errno::Errno;
 use nix::sys::epoll::Epoll;
@@ -115,6 +117,13 @@ impl From<NewPictureError> for DecodeError {
             }
         }
     }
+}
+
+/// Error returned by the [`StatelessVideoDecoder::wait_for_next_event`] method.
+#[derive(Debug, Error)]
+pub enum WaitNextEventError {
+    #[error("timed out while waiting for next decoder event")]
+    TimedOut,
 }
 
 mod private {
@@ -317,6 +326,25 @@ pub trait StatelessVideoDecoder {
 
     /// Returns the next event, if there is any pending.
     fn next_event(&mut self) -> Option<DecoderEvent<Self::Handle>>;
+
+    /// Blocks until [`StatelessVideoDecoder::next_event`] is expected to return `Some` or
+    /// `timeout` has elapsed.
+    ///
+    /// Wait for the next event and return it, or return `None` if `timeout` has been reached while
+    /// waiting.
+    fn wait_for_next_event(&mut self, timeout: Duration) -> Result<(), WaitNextEventError> {
+        // Wait until the next event is available.
+        let mut fd = nix::libc::pollfd {
+            fd: self.poll_fd().as_raw_fd(),
+            events: nix::libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: `fd` is a valid reference to a properly-filled `pollfd`.
+        match unsafe { nix::libc::poll(&mut fd, 1, timeout.as_millis() as i32) } {
+            0 => Err(WaitNextEventError::TimedOut),
+            _ => Ok(()),
+        }
+    }
 
     /// Returns a file descriptor that signals `POLLIN` whenever an event is pending on this
     /// decoder.

--- a/src/decoder/stateless/av1.rs
+++ b/src/decoder/stateless/av1.rs
@@ -326,7 +326,7 @@ where
             // This OBU should be dropped.
             ParsedObu::Drop(length) => return Ok(length as usize),
         };
-        let obu_length = obu.data.len();
+        let obu_length = obu.bytes_used;
 
         let is_decode_op = matches!(
             obu.header.obu_type,

--- a/src/decoder/stateless/av1.rs
+++ b/src/decoder/stateless/av1.rs
@@ -433,6 +433,12 @@ where
             }
             ObuType::Frame => {
                 let frame = self.codec.parser.parse_frame_obu(obu)?;
+                if self.codec.current_pic.is_some() {
+                    /* submit this frame immediately, as we need to update the
+                     * DPB and the reference info state *before* processing the
+                     * next frame */
+                    self.submit_frame(timestamp)?;
+                }
                 self.decode_frame(frame, timestamp)?;
                 /* submit this frame immediately, as we need to update the
                  * DPB and the reference info state *before* processing the

--- a/src/decoder/stateless/av1.rs
+++ b/src/decoder/stateless/av1.rs
@@ -11,8 +11,8 @@ use anyhow::anyhow;
 use crate::codec::av1::parser::FrameHeaderObu;
 use crate::codec::av1::parser::FrameObu;
 use crate::codec::av1::parser::FrameType;
+use crate::codec::av1::parser::ObuAction;
 use crate::codec::av1::parser::ObuType;
-use crate::codec::av1::parser::ParsedObu;
 use crate::codec::av1::parser::Parser;
 use crate::codec::av1::parser::SequenceHeaderObu;
 use crate::codec::av1::parser::TileGroupObu;
@@ -321,10 +321,10 @@ where
     /// method will only consume a single OBU. The caller must be careful to check the return value
     /// and resubmit the remainder if the whole bitstream has not been consumed.
     fn decode(&mut self, timestamp: u64, bitstream: &[u8]) -> Result<usize, DecodeError> {
-        let obu = match self.codec.parser.parse_obu(bitstream)? {
-            ParsedObu::Process(obu) => obu,
+        let obu = match self.codec.parser.read_obu(bitstream)? {
+            ObuAction::Process(obu) => obu,
             // This OBU should be dropped.
-            ParsedObu::Drop(length) => return Ok(length as usize),
+            ObuAction::Drop(length) => return Ok(length as usize),
         };
         let obu_length = obu.bytes_used;
 

--- a/src/decoder/stateless/av1.rs
+++ b/src/decoder/stateless/av1.rs
@@ -349,11 +349,7 @@ where
                     let mut parser = self.codec.parser.clone();
 
                     let is_key_frame = match obu.header.obu_type {
-                        ObuType::Frame => {
-                            let frame = parser.parse_frame_obu(obu.clone())?;
-                            frame.header.frame_type == FrameType::KeyFrame
-                        }
-                        ObuType::FrameHeader => {
+                        ObuType::Frame | ObuType::FrameHeader => {
                             let fh = parser.parse_frame_header_obu(&obu)?;
                             fh.frame_type == FrameType::KeyFrame
                         }

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -607,6 +607,9 @@ where
             .find_short_term_with_pic_num(pic_num_lx)
             .with_context(|| format!("No ShortTerm reference found with pic_num {}", pic_num_lx))?;
 
+        if *ref_idx_lx >= ref_pic_list_x.len() {
+            anyhow::bail!("invalid ref_idx_lx index");
+        }
         ref_pic_list_x.insert(*ref_idx_lx, handle);
         *ref_idx_lx += 1;
 
@@ -651,6 +654,9 @@ where
                 )
             })?;
 
+        if *ref_idx_lx >= ref_pic_list_x.len() {
+            anyhow::bail!("invalid ref_idx_lx index");
+        }
         ref_pic_list_x.insert(*ref_idx_lx, handle);
         *ref_idx_lx += 1;
 

--- a/src/decoder/stateless/h264.rs
+++ b/src/decoder/stateless/h264.rs
@@ -517,7 +517,7 @@ where
                 let last_pic = last_dpb_entry.pic.borrow();
 
                 if !matches!(last_pic.field, Field::Frame) && last_pic.other_field().is_none() {
-                    if let Some(handle) = &last_dpb_entry.handle {
+                    if let Some(handle) = &last_dpb_entry.reference {
                         // Still waiting for the second field
                         prev_field = Some((&last_dpb_entry.pic, handle));
                     }

--- a/src/decoder/stateless/h264/vaapi.rs
+++ b/src/decoder/stateless/h264/vaapi.rs
@@ -227,7 +227,7 @@ fn build_pic_param<M: SurfaceMemoryDescriptor>(
     let mut va_refs = vec![];
 
     for handle in &refs {
-        let surface_id = va_surface_id(&handle.handle);
+        let surface_id = va_surface_id(&handle.reference);
         let ref_pic = handle.pic.borrow();
         let pic = fill_va_h264_pic(&ref_pic, surface_id, true);
         va_refs.push(pic);
@@ -245,7 +245,7 @@ fn build_pic_param<M: SurfaceMemoryDescriptor>(
         .collect();
 
     for handle in &refs {
-        let surface_id = va_surface_id(&handle.handle);
+        let surface_id = va_surface_id(&handle.reference);
         let ref_pic = handle.pic.borrow();
         let pic = fill_va_h264_pic(&ref_pic, surface_id, true);
         va_refs.push(pic);
@@ -325,7 +325,7 @@ fn fill_ref_pic_list<M: SurfaceMemoryDescriptor>(
     let mut va_pics = vec![];
 
     for handle in ref_list_x {
-        let surface_id = va_surface_id(&handle.handle);
+        let surface_id = va_surface_id(&handle.reference);
         let ref_pic = handle.pic.borrow();
         let merge = matches!(ref_pic.field, Field::Frame);
         let va_pic = fill_va_h264_pic(&ref_pic, surface_id, merge);

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -935,10 +935,6 @@ where
 
         let pic = PictureData::new_from_slice(
             slice,
-            self.codec
-                .parser
-                .get_pps(slice.header.pic_parameter_set_id)
-                .context("Invalid PPS")?,
             self.codec.first_picture_in_bitstream,
             self.codec.first_picture_after_eos,
             self.codec.prev_tid_0_pic.as_ref(),

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -972,15 +972,10 @@ where
             .parser
             .get_pps(slice.header.pic_parameter_set_id)
             .context("invalid PPS ID")?;
-        let sps = self
-            .codec
-            .parser
-            .get_sps(pps.seq_parameter_set_id)
-            .context("invalid SPS ID")?;
         self.backend.begin_picture(
             &mut backend_pic,
             &pic,
-            sps,
+            pps.sps.as_ref(),
             pps,
             &self.codec.dpb,
             &self.codec.rps,
@@ -1032,15 +1027,10 @@ where
             .parser
             .get_pps(slice.header.pic_parameter_set_id)
             .context("invalid PPS ID")?;
-        let sps = self
-            .codec
-            .parser
-            .get_sps(pps.seq_parameter_set_id)
-            .context("invalid SPS ID")?;
         self.backend.decode_slice(
             &mut pic.backend_pic,
             slice,
-            sps,
+            pps.sps.as_ref(),
             pps,
             &pic.ref_pic_lists.ref_pic_list0,
             &pic.ref_pic_lists.ref_pic_list1,

--- a/src/decoder/stateless/h265.rs
+++ b/src/decoder/stateless/h265.rs
@@ -887,7 +887,10 @@ where
 
     // See C.5.2.2
     fn update_dpb_before_decoding(&mut self, cur_pic: &PictureData) -> anyhow::Result<()> {
-        if cur_pic.is_irap && cur_pic.no_rasl_output_flag && !self.codec.first_picture_after_eos {
+        if cur_pic.nalu_type.is_irap()
+            && cur_pic.no_rasl_output_flag
+            && !self.codec.first_picture_after_eos
+        {
             if cur_pic.no_output_of_prior_pics_flag {
                 self.codec.dpb.clear();
             } else {
@@ -944,7 +947,7 @@ where
         self.codec.first_picture_after_eos = false;
         self.codec.first_picture_in_bitstream = false;
 
-        if pic.is_irap {
+        if pic.nalu_type.is_irap() {
             self.codec.irap_no_rasl_output_flag = pic.no_rasl_output_flag;
         } else if pic.nalu_type.is_rasl() && self.codec.irap_no_rasl_output_flag {
             // NOTE – All RASL pictures are leading pictures of an associated

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,6 +13,7 @@ use std::io::Seek;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
+use std::time::Duration;
 
 use byteorder::ReadBytesExt;
 use byteorder::LE;
@@ -346,6 +347,7 @@ where
                     }
                 }
                 Err(DecodeError::CheckEvents) | Err(DecodeError::NotEnoughOutputBuffers(_)) => {
+                    decoder.wait_for_next_event(Duration::from_secs(3))?;
                     check_events(decoder)?
                 }
                 Err(e) => anyhow::bail!(e),


### PR DESCRIPTION
Hi Hiro,

These are the changes that were pending on my local branches and weren't pushed yet. Mostly small and easy fixes as well as readability improvements, although H.264 has some more involved stuff to remove unneeded complexity. Some of the efforts are still not complete though, like the removal of `anyhow`, where I just pushed what I had.

I have ran the full Fluster suite with these changes and haven't seen any regression.